### PR TITLE
ci(repo): refactor renovate to cut noice and make improvements

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,29 +1,58 @@
 {
-  "$schema": "http://json.schemastore.org/renovate",
-  "extends": ["config:base", ":semanticCommitScopeDisabled"],
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+
+  "extends": ["config:recommended", ":semanticCommitScopeDisabled"],
+  "baseBranches": ["main"],
+
+  "schedule": ["after 12am on sunday"],
+  "timezone": "Europe/Stockholm",
+
   "automerge": true,
   "automergeType": "branch",
-  "baseBranches": ["main"],
-  "updateInternalDeps": true,
+  "rebaseWhen": "auto",
+  "minimumReleaseAge": "3 days",
+  "prConcurrentLimit": 10,
+  "prHourlyLimit": 4,
+
+  "labels": ["dependencies"],
+  "semanticCommits": "enabled",
+  "semanticCommitType": "chore",
+  "semanticCommitScope": "deps",
+
+  "groupName": "Weekly Dependencies",
+  "group": {
+    "commitMessageTopic": "dependencies"
+  },
+
+  "rangeStrategy": "auto",
+
+  "dependencyDashboard": true,
+
   "lockFileMaintenance": {
     "enabled": true,
-    "automerge": true,
-    "automergeType": "branch",
-    "commitMessageAction": "📦 lock file maintenance",
-    "semanticCommitType": "build"
+    "schedule": ["after 12am on sunday"]
   },
-  "rangeStrategy": "update-lockfile",
-  "commitMessageAction": "📦 bump",
+
   "packageRules": [
     {
-      "matchPackagePatterns": ["nx"],
-      "groupName": "Nx related (skip)",
+      "description": "Security updates configuration",
+      "matchUpdateTypes": ["patch", "minor", "major"],
+      "matchCategories": ["security"],
+      "automerge": true,
+      "prCreation": "immediate",
+      "prConcurrentLimit": 0,
+      "groupName": "Security updates"
+    },
+    {
+      "description": "Skip major updates for packages migrated to ESM only",
+      "matchPackageNames": ["@octokit/request-error", "replace-in-file"],
+      "matchUpdateTypes": ["major"],
       "enabled": false
     },
-    { "matchPackagePatterns": ["*"], "semanticCommitType": "build" },
     {
-      "matchDepTypes": ["dependencies", "require"],
-      "semanticCommitType": "fix"
+      "description": "Skip all Nx package updates",
+      "matchPackageNames": ["create-nx-workspace", "nx", "@nx/**", "@nrwl/**"],
+      "enabled": false
     }
   ]
 }

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -20,6 +20,11 @@ pre-commit:
       run: npx eslint --fix "{staged_files}"
       stage_fixed: true
 
+    # Validate Renovate config and suggest migrations
+    renovate:
+      glob: '.github/renovate.json'
+      run: npx --yes --package renovate -- renovate-config-validator --strict
+
 # Lint commit message after pre-commit
 commit-msg:
   commands:


### PR DESCRIPTION
Main changes

- Defer pull requests to once a week
- Allow security issues to update ad-hoc
- Skip packages that when updated require ESM
- Revert custom commit messages and other texts to default
- Enable dependency dashboard
- Add renovate validation to git commit hook

closed COD-160