### PR TITLE
Support Infisical secrets management

### DIFF
--- a/.github/workflows/fly-deployment.yml
+++ b/.github/workflows/fly-deployment.yml
@@ -89,6 +89,8 @@ jobs:
           main-branch-name: main
           set-environment-variables-for-job: true
 
+      # TODO: Fetch all tenants and make a deployment for each with their `TENANT_ID`
+      # TODO: Alternatively, create a new input with multi-tenant values
       - name: Run Deployment to Fly
         id: deployment
         uses: ./packages/nx-fly-deployment-action
@@ -97,3 +99,8 @@ jobs:
           fly-org: ${{ vars.FLY_ORG }}
           fly-region: ${{ vars.FLY_REGION }}
           token: ${{ steps.generate-token.outputs.token }}
+          env: |
+            TENANT_ID=default
+          secrets: |
+            INFISICAL_CLIENT_ID=${{ secrets.INFISICAL_READ_CLIENT_ID }}
+            INFISICAL_CLIENT_SECRET=${{ secrets.INFISICAL_READ_CLIENT_SECRET }}

--- a/.infisical.json
+++ b/.infisical.json
@@ -1,0 +1,5 @@
+{
+  "workspaceId": "abb137af-e48b-4dc9-96eb-451a3ce36494",
+  "defaultEnvironment": "development",
+  "gitBranchToEnvironmentMapping": null
+}

--- a/README.md
+++ b/README.md
@@ -64,6 +64,31 @@ A set of core utilities for the [Codeware](https://codeware.se) ecosystem.
 
 ## Development
 
+### Infisical Secret Management
+
+The [Infisical](https://infisical.com) secret management tool is used to manage secrets for the Codeware ecosystem.
+
+1. [Install Infisical CLI](https://infisical.com/docs/cli/overview#installation)
+
+2. Login to access the secrets
+
+   ```sh
+   infisical login
+   ```
+
+3. List the development secrets
+
+   ```sh
+   # all secrets
+   infisical secrets --recursive
+
+   # cms application
+   infisical secrets --recursive --path /cms
+
+   # web application
+   infisical secrets --recursive --path /web
+   ```
+
 ### Release management
 
 The release process is semi-automatic which means:

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -35,6 +35,7 @@ RUN pnpm install --prod
 COPY --from=build /app/apps/web/build ./build
 COPY --from=build /app/apps/web/public ./public
 COPY --from=build /app/apps/web/server.js ./
+COPY --from=build /app/.infisical.json ./
 
 EXPOSE 3001
 CMD [ "node", "server.js" ]

--- a/apps/web/app/api/fetch-pages.ts
+++ b/apps/web/app/api/fetch-pages.ts
@@ -15,7 +15,9 @@ export const fetchPages = async (): Promise<Page[]> => {
   );
 
   if (!response.ok) {
-    throw new Error(`Error fetching pages: ${response.status}`);
+    throw new Error(
+      `Error fetching pages: ${response.status}\n${response.statusText}`
+    );
   }
 
   const pageRes: PageResult = await response.json();

--- a/apps/web/app/routes/resources.theme-switch.tsx
+++ b/apps/web/app/routes/resources.theme-switch.tsx
@@ -9,6 +9,13 @@ import { useHints } from '../utils/client-hints';
 import { useRequestInfo } from '../utils/request-info';
 import { Theme, setTheme } from '../utils/theme.server';
 
+// Resolve a reusable actio type
+type ActionData = {
+  result: ReturnType<
+    Awaited<ReturnType<typeof parseWithZod<typeof ThemeFormSchema>>>['reply']
+  >;
+};
+
 const ThemeFormSchema = z.object({
   theme: z.enum(['system', 'light', 'dark']),
   // Used when the page has not hydrated yet for progressive enhancement
@@ -32,7 +39,7 @@ export async function action({ request }: ActionFunctionArgs) {
     return redirect(redirectTo, responseInit);
   }
 
-  return data({ result: submission.reply() }, responseInit);
+  return data<ActionData>({ result: submission.reply() }, responseInit);
 }
 
 export function ThemeSwitch({
@@ -40,7 +47,7 @@ export function ThemeSwitch({
 }: {
   userPreference?: Theme | null;
 }) {
-  const fetcher = useFetcher<typeof action>();
+  const fetcher = useFetcher<ActionData>();
   const optimisticMode = useOptimisticThemeMode();
   const requestInfo = useRequestInfo();
 

--- a/apps/web/eslint.config.cjs
+++ b/apps/web/eslint.config.cjs
@@ -3,7 +3,7 @@ const baseConfig = require('../../eslint.config.js');
 module.exports = [
   ...baseConfig,
   {
-    ignores: ['**/build', '**/vitest.config.ts.timestamp*']
+    ignores: ['**/build', '**/server.js', '**/vitest.config.ts.timestamp*']
   },
   {
     files: ['**/*.json'],
@@ -13,6 +13,7 @@ module.exports = [
         {
           ignoredDependencies: [
             '@cdwr/core',
+            '@infisical/sdk',
             '@nx/vite',
             '@remix-run/testing',
             '@testing-library/jest-dom',

--- a/apps/web/fly.toml
+++ b/apps/web/fly.toml
@@ -1,11 +1,6 @@
 app = 'cdwr-web'
 primary_region = 'arn'
 
-[env]
-  PAYLOAD_API_KEY = 'to-be-set'
-  PAYLOAD_URL = 'https://to-be-set.noop.io'
-  PORT = '3001'
-
 [build]
   dockerfile = "Dockerfile"
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,40 +1,46 @@
 {
-  "private": true,
-  "name": "web",
-  "scripts": {},
-  "type": "module",
-  "dependencies": {
-    "@conform-to/react": "^1.2.2",
-    "@conform-to/zod": "^1.2.2",
-    "@epic-web/client-hints": "^1.3.5",
-    "@hono/node-server": "^1.13.7",
-    "@remix-run/node": "^2.14.0",
-    "@remix-run/react": "^2.14.0",
-    "clsx": "^2.1.1",
-    "hono": "^4.6.10",
-    "isbot": "^5.0.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "remix-hono": "^0.0.16",
-    "remix-utils": "^7.7.0",
-    "tiny-invariant": "^1.3.3",
-    "zod": "^3.23.8"
+  "compileOnSave": false,
+  "compilerOptions": {
+    "rootDir": ".",
+    "sourceMap": true,
+    "declaration": false,
+    "lib": ["es2022", "dom"],
+    "strict": true,
+    "skipLibCheck": true,
+    "moduleResolution": "node",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "importHelpers": true,
+    "target": "es2022",
+    "module": "esnext",
+    "lib": ["es2022", "dom"],
+    "strict": true,
+    "skipLibCheck": true,
+    "skipDefaultLibCheck": true,
+    "baseUrl": ".",
+    "paths": {
+      "@codeware/core/actions": ["packages/core/src/actions.ts"],
+      "@codeware/core/release": ["packages/core/src/release.ts"],
+      "@codeware/core/testing": ["packages/core/src/testing.ts"],
+      "@codeware/core/utils": ["packages/core/src/utils.ts"],
+      "@codeware/core/zod": ["packages/core/src/zod.ts"],
+      "@codeware/create-nx-payload": [
+        "packages/create-nx-payload/bin/index.ts"
+      ],
+      "@codeware/deploy-env-action": [
+        "packages/deploy-env-action/src/index.ts"
+      ],
+      "@codeware/e2e/utils": ["e2e/utils/index.ts"],
+      "@codeware/fly-node": ["packages/fly-node/src/index.ts"],
+      "@codeware/nx-fly-deployment-action": [
+        "packages/nx-fly-deployment-action/src/index.ts"
+      ],
+      "@codeware/nx-migrate-action": [
+        "packages/nx-migrate-action/src/index.ts"
+      ],
+      "@codeware/nx-payload": ["packages/nx-payload/index.ts"],
+      "@codeware/shared/util/payload": ["libs/shared/util/payload/src/index.ts"]
+    }
   },
-  "devDependencies": {
-    "@nx/vite": "20.1.4",
-    "@remix-run/dev": "^2.14.0",
-    "@types/react": "^18.2.0",
-    "@types/react-dom": "^18.2.0",
-    "@remix-run/testing": "^2.14.0",
-    "@testing-library/jest-dom": "6.6.3",
-    "@testing-library/react": "16.0.1",
-    "@vitejs/plugin-react": "^4.2.0",
-    "eslint": "^9.0.0",
-    "typescript": "~5.7.0",
-    "vite": "^5.0.0"
-  },
-  "engines": {
-    "node": ">=20"
-  },
-  "sideEffects": false
+  "exclude": ["node_modules", "tmp"]
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,46 +1,41 @@
 {
-  "compileOnSave": false,
-  "compilerOptions": {
-    "rootDir": ".",
-    "sourceMap": true,
-    "declaration": false,
-    "lib": ["es2022", "dom"],
-    "strict": true,
-    "skipLibCheck": true,
-    "moduleResolution": "node",
-    "emitDecoratorMetadata": true,
-    "experimentalDecorators": true,
-    "importHelpers": true,
-    "target": "es2022",
-    "module": "esnext",
-    "lib": ["es2022", "dom"],
-    "strict": true,
-    "skipLibCheck": true,
-    "skipDefaultLibCheck": true,
-    "baseUrl": ".",
-    "paths": {
-      "@codeware/core/actions": ["packages/core/src/actions.ts"],
-      "@codeware/core/release": ["packages/core/src/release.ts"],
-      "@codeware/core/testing": ["packages/core/src/testing.ts"],
-      "@codeware/core/utils": ["packages/core/src/utils.ts"],
-      "@codeware/core/zod": ["packages/core/src/zod.ts"],
-      "@codeware/create-nx-payload": [
-        "packages/create-nx-payload/bin/index.ts"
-      ],
-      "@codeware/deploy-env-action": [
-        "packages/deploy-env-action/src/index.ts"
-      ],
-      "@codeware/e2e/utils": ["e2e/utils/index.ts"],
-      "@codeware/fly-node": ["packages/fly-node/src/index.ts"],
-      "@codeware/nx-fly-deployment-action": [
-        "packages/nx-fly-deployment-action/src/index.ts"
-      ],
-      "@codeware/nx-migrate-action": [
-        "packages/nx-migrate-action/src/index.ts"
-      ],
-      "@codeware/nx-payload": ["packages/nx-payload/index.ts"],
-      "@codeware/shared/util/payload": ["libs/shared/util/payload/src/index.ts"]
-    }
+  "private": true,
+  "name": "web",
+  "scripts": {},
+  "type": "module",
+  "dependencies": {
+    "@conform-to/react": "^1.2.2",
+    "@conform-to/zod": "^1.2.2",
+    "@epic-web/client-hints": "^1.3.5",
+    "@hono/node-server": "^1.13.7",
+    "@infisical/sdk": "^3.0.4",
+    "@remix-run/node": "^2.14.0",
+    "@remix-run/react": "^2.14.0",
+    "clsx": "^2.1.1",
+    "hono": "^4.6.10",
+    "isbot": "^5.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "remix-hono": "^0.0.16",
+    "remix-utils": "^7.7.0",
+    "tiny-invariant": "^1.3.3",
+    "zod": "^3.23.8"
   },
-  "exclude": ["node_modules", "tmp"]
+  "devDependencies": {
+    "@nx/vite": "20.1.4",
+    "@remix-run/dev": "^2.14.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@remix-run/testing": "^2.14.0",
+    "@testing-library/jest-dom": "6.6.3",
+    "@testing-library/react": "16.0.1",
+    "@vitejs/plugin-react": "^4.2.0",
+    "eslint": "^9.0.0",
+    "typescript": "~5.7.0",
+    "vite": "^5.0.0"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "sideEffects": false
 }

--- a/apps/web/project.json
+++ b/apps/web/project.json
@@ -14,13 +14,26 @@
         }
       },
       "executor": "nx:run-commands",
+      "outputs": [
+        "{workspaceRoot}/apps/web/build",
+        "{workspaceRoot}/apps/web/server.js"
+      ],
       "options": {
-        "commands": [
-          "remix vite:build ./apps/web",
-          "vite build --config ./apps/web/vite.server.config.ts"
-        ],
+        "commands": ["nx build-remix web", "nx build-server web"],
         "parallel": false
-      }
+      },
+      "cache": true
+    },
+    "build-server": {
+      "executor": "@nx/vite:build",
+      "outputs": ["{options.outputPath}/server.js"],
+      "options": {
+        "outputPath": "{workspaceRoot}/apps/web",
+        "configFile": "apps/web/vite.server.config.ts",
+        "generatePackageJson": false,
+        "watch": false
+      },
+      "cache": true
     },
     "build-remix": {
       "metadata": {
@@ -29,21 +42,22 @@
           "command": "nx build-remix web"
         }
       },
-      "executor": "nx:run-commands",
-      "options": {
-        "commands": ["remix vite:build ./apps/web"]
-      }
+      "command": "remix vite:build ./apps/web",
+      "outputs": ["{workspaceRoot}/apps/web/build"],
+      "cache": true
     },
     "start": {
       "executor": "nx:run-commands",
       "metadata": {
-        "description": "Start the Hono server in production mode",
+        "description": "Start the Hono server in production mode with secrets from default tenant",
         "help": {
           "command": "nx start web"
         }
       },
       "options": {
-        "commands": ["NODE_ENV=production node server.js"],
+        "commands": [
+          "NODE_ENV=production infisical run --path /web/tenants/default -- node server.js"
+        ],
         "cwd": "apps/web"
       },
       "dependsOn": ["build"]

--- a/apps/web/server.ts
+++ b/apps/web/server.ts
@@ -6,12 +6,14 @@ import { serve } from '@hono/node-server';
 import { serveStatic } from '@hono/node-server/serve-static';
 import type { ServerBuild } from '@remix-run/node';
 import { Hono } from 'hono';
-import { remix } from 'remix-hono/handler';
+import { type RemixMiddlewareOptions, remix } from 'remix-hono/handler';
 
 import env from './env';
 
 // Load the Remix server build
-const build = (await import('./build/server/index.js')) as ServerBuild;
+const build = (await import(
+  './build/server/index.js'
+)) as unknown as ServerBuild;
 
 const app = new Hono()
   // Serve static files from Remix client build
@@ -21,7 +23,7 @@ const app = new Hono()
     '*',
     remix({
       build,
-      mode: env.NODE_ENV
+      mode: env.NODE_ENV as RemixMiddlewareOptions['mode']
     })
   );
 

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "lib": ["DOM", "DOM.Iterable", "ES2019"],
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
     "types": ["@remix-run/node", "vite/client"],
     "isolatedModules": true,
     "esModuleInterop": true,

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -8,8 +8,23 @@ declare module '@remix-run/node' {
   }
 }
 
+/**
+ * Output build path limitation!
+ *
+ * We can force the output to be written to workspace root `dist` using remix config:
+ *  buildDirectory: '../../dist/apps/web/build'
+ *
+ * However this makes the compiled property `assetsBuildDirectory` in `server/index.js`
+ * point to the wrong path, and there is no way to override it (as I know it (Håkan)).
+ *
+ * Therefore we stick to output compiled code to app root until we know better.
+ */
+
 export default defineConfig({
   root: __dirname,
+  build: {
+    target: ['node20', 'esnext']
+  },
   plugins: [
     remix({
       future: {

--- a/apps/web/vite.server.config.ts
+++ b/apps/web/vite.server.config.ts
@@ -1,11 +1,13 @@
+import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
+  root: __dirname,
   build: {
     ssr: true,
-    outDir: './apps/web',
-    emptyOutDir: false,
-    target: 'node20',
+    outDir: './', // Effective output path is configured in project.json
+    emptyOutDir: false, // Important!
+    target: ['node20', 'esnext'],
     rollupOptions: {
       input: './apps/web/server.ts',
       output: {
@@ -16,6 +18,7 @@ export default defineConfig({
       external: ['./build/server/index.js']
     }
   },
+  plugins: [nxViteTsPaths()],
   // Exlude public directory from the build
   publicDir: false
 });

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@conform-to/zod": "^1.2.2",
     "@epic-web/client-hints": "^1.3.5",
     "@hono/node-server": "^1.13.7",
+    "@infisical/sdk": "^3.0.4",
     "@octokit/request-error": "^5.0.1",
     "@payloadcms/bundler-webpack": "1.0.7",
     "@payloadcms/db-mongodb": "1.7.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,10 +17,13 @@
   "keywords": [
     "CLI",
     "Codeware",
+    "Environment variables",
     "Fixtures",
     "GitHub Actions",
+    "Infisical",
     "Nx",
     "Release management",
+    "Secrets",
     "Testing",
     "Utilities",
     "Zod"
@@ -32,6 +35,7 @@
     "@actions/core": "^1.11.1",
     "@actions/github": "^6.0.0",
     "@clack/prompts": "^0.8.0",
+    "@infisical/sdk": "^3.0.4",
     "@nx/devkit": "20.x",
     "@nx/plugin": "20.x",
     "@octokit/request-error": "^5.0.1",
@@ -60,6 +64,11 @@
       "types": "./src/release.d.ts",
       "import": "./release.js",
       "require": "./release.cjs"
+    },
+    "./secrets": {
+      "types": "./src/secrets.d.ts",
+      "import": "./secrets.js",
+      "require": "./secrets.cjs"
     },
     "./testing": {
       "types": "./src/testing.d.ts",

--- a/packages/core/project.json
+++ b/packages/core/project.json
@@ -19,7 +19,10 @@
         "additionalEntryPoints": [
           "packages/core/src/actions.ts",
           "packages/core/src/release.ts",
-          "packages/core/src/utils.ts"
+          "packages/core/src/secrets.ts",
+          "packages/core/src/testing.ts",
+          "packages/core/src/utils.ts",
+          "packages/core/src/zod.ts"
         ],
         "format": ["cjs", "esm"]
       }

--- a/packages/core/src/lib/secrets/find-up-fs.ts
+++ b/packages/core/src/lib/secrets/find-up-fs.ts
@@ -1,0 +1,47 @@
+import { constants } from 'fs';
+import { access } from 'fs/promises';
+import { dirname, join, parse, resolve } from 'path';
+import { cwd } from 'process';
+
+/**
+ * Searches for a file by walking up parent directories.
+ *
+ * Similar to `find-up` but uses `fs` to check for the file.
+ *
+ * @param filename - Name of the file to find
+ * @param startDir - Directory to start searching from (defaults to current working directory)
+ * @returns Full path to the file or `null` if not found
+ */
+export async function findUpFs(
+  filename: string,
+  startDir: string = cwd()
+): Promise<string | null> {
+  let currentDir = resolve(startDir);
+  const root = parse(currentDir).root;
+
+  while (true) {
+    const filePath = join(currentDir, filename);
+
+    try {
+      // Check if file exists and is accessible
+      await access(filePath, constants.F_OK);
+      return filePath;
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    } catch (_) {
+      // If we've reached the root directory and haven't found the file
+      if (currentDir === root) {
+        return null;
+      }
+
+      // Move up to parent directory
+      const parentDir = dirname(currentDir);
+
+      // If we can't go up any further
+      if (parentDir === currentDir) {
+        return null;
+      }
+
+      currentDir = parentDir;
+    }
+  }
+}

--- a/packages/core/src/lib/secrets/infisical.schemas.ts
+++ b/packages/core/src/lib/secrets/infisical.schemas.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+
+/**
+ * Infisical client credentials from environment variables
+ */
+export const ClientSchema = z.object({
+  INFISICAL_CLIENT_ID: z
+    .string({ description: 'Infisical Machine Client ID' })
+    .min(1, 'Environment variable INFISICAL_CLIENT_ID is required'),
+  INFISICAL_CLIENT_SECRET: z
+    .string({ description: 'Infisical Machine Client Secret' })
+    .min(1, 'Environment variable INFISICAL_CLIENT_SECRET is required')
+});
+
+/**
+ * Infisical project environment values
+ */
+export const EnvironmentSchema = z.enum(
+  ['development', 'preview', 'production'],
+  {
+    description: 'The environment to get the secrets from'
+  }
+);
+
+/**
+ * Infisical configuration from `.infisical.json`
+ */
+export const ConfigSchema = z.object({
+  workspaceId: z
+    .string({
+      description: 'The ID of the project to connect to'
+    })
+    .min(1, {
+      message: 'Workspace ID is required'
+    }),
+  defaultEnvironment: EnvironmentSchema.optional(),
+  gitBranchToEnvironmentMapping: z
+    .record(z.string(), z.string(), {
+      description: 'The mapping of git branches to environments'
+    })
+    .nullable()
+    .optional()
+});
+
+export type Client = z.infer<typeof ClientSchema>;
+export type Config = z.infer<typeof ConfigSchema>;
+export type Environment = z.infer<typeof EnvironmentSchema>;

--- a/packages/core/src/lib/secrets/read-infisical-config.ts
+++ b/packages/core/src/lib/secrets/read-infisical-config.ts
@@ -1,0 +1,29 @@
+import { readFile } from 'fs/promises';
+
+import { findUpFs } from './find-up-fs';
+import { ConfigSchema } from './infisical.schemas';
+
+/**
+ * Read the Infisical configuration file `.infisical.json`
+ *
+ * @returns The parsed Infisical configuration
+ * @throws An error if the configuration file is not found or is not valid
+ */
+export const readInfisicalConfig = async () => {
+  const filePath = await findUpFs('.infisical.json');
+  if (!filePath) {
+    throw new Error('Infisical configuration file not found');
+  }
+  const content = await readFile(filePath, 'utf-8');
+
+  const jsonContent = JSON.parse(content);
+
+  const parsed = ConfigSchema.safeParse(jsonContent);
+  if (!parsed.success) {
+    throw new Error('Invalid Infisical configuration file', {
+      cause: parsed.error.flatten().fieldErrors
+    });
+  }
+
+  return parsed.data;
+};

--- a/packages/core/src/lib/secrets/with-infisical.ts
+++ b/packages/core/src/lib/secrets/with-infisical.ts
@@ -1,0 +1,164 @@
+import { InfisicalSDK } from '@infisical/sdk';
+
+import { ClientSchema, type Environment } from './infisical.schemas';
+import { readInfisicalConfig } from './read-infisical-config';
+
+type Filter = {
+  /**
+   * Folder-based path to the secrets.
+   *
+   * Defaults to the root folder.
+   */
+  path?: string;
+  /**
+   * Whether to recurse into subfolders.
+   *
+   * Defaults to `false`.
+   */
+  recurse?: boolean;
+  /**
+   * Tags to filter the secrets by.
+   */
+  tags?: Array<string>;
+};
+
+type Options<TEnv> = {
+  /**
+   * The environment to get the secrets from.
+   *
+   * Defaults to the environment in the Infisical configuration file
+   * or 'development' if not available.
+   */
+  environment?: TEnv;
+  /**
+   * The optional filters to apply to the secrets.
+   */
+  filter?: Filter;
+  /**
+   * The action to perform when the client is authenticated.
+   *
+   * **`inject`**
+   *
+   * Get the secrets from your project and inject them into the `process.env` object.
+   * Use early in your application to ensure that the secrets are available as soon as possible.
+   */
+  onConnect?: 'inject';
+  /**
+   * The project ID to get the secrets from.
+   *
+   * Defaults to the project ID in the Infisical configuration file.
+   */
+  projectId?: string;
+  /**
+   * Whether to ignore exceptions and just output warnings.
+   *
+   * Defaults to `false`.
+   */
+  silent?: boolean;
+  /**
+   * The site to use for the Infisical client.
+   *
+   * Defaults to `'us'`.
+   */
+  site?: 'eu' | 'us';
+};
+
+/**
+ * Utility function to connect and authenticate to Infisical.
+ *
+ * **Requirements:**
+ *
+ * - `INFISICAL_CLIENT_ID` and `INFISICAL_CLIENT_SECRET` must be available in the environment variables.
+ * - A project ID, either from `options` or the Infisical configuration file `.infisical.json`.
+ *
+ * @returns The authenticated Infisical SDK client
+ * @throws An error if the environment variables are invalid or the client fails to authenticate
+ */
+export const withInfisical = async <TEnv = Environment>(
+  options?: Options<TEnv>
+): Promise<InfisicalSDK | null> => {
+  const { success, data, error } = ClientSchema.safeParse(process.env);
+
+  if (!success) {
+    const msg = 'Could not resolve client credentials';
+    if (!options?.silent) {
+      throw new Error(msg, {
+        cause: error.flatten().fieldErrors
+      });
+    }
+
+    console.warn(msg);
+    console.warn(JSON.stringify(error.flatten().fieldErrors, null, 2));
+    return null;
+  }
+
+  const {
+    INFISICAL_CLIENT_ID: clientId,
+    INFISICAL_CLIENT_SECRET: clientSecret
+  } = data;
+
+  try {
+    const environment: string =
+      options?.environment?.toString() ?? ('development' satisfies Environment);
+    console.log(`[Infisical] use environment '${environment}'`);
+
+    const projectId =
+      options?.projectId ?? (await readInfisicalConfig()).workspaceId;
+    console.log(`[Infisical] use project '${projectId}'`);
+
+    // Default site is US
+    const client = new InfisicalSDK({
+      siteUrl: options?.site === 'eu' ? 'https://eu.infisical.com' : undefined
+    });
+
+    // Connect to Infisical
+    const ref = await client.auth().universalAuth.login({
+      clientId,
+      clientSecret
+    });
+
+    console.log('[Infisical] connected successfully');
+
+    // Action to perform when the client is authenticated
+    switch (options?.onConnect) {
+      case 'inject': {
+        const { secrets } = await client.secrets().listSecrets({
+          environment,
+          projectId,
+          expandSecretReferences: true,
+          recursive: options?.filter?.recurse ?? false,
+          secretPath: options?.filter?.path,
+          tagSlugs: options?.filter?.tags
+        });
+        console.log(
+          `[Infisical] inject ${secrets.length} secrets into process.env`
+        );
+        for (const { secretKey, secretValue } of secrets) {
+          process.env[secretKey] = secretValue;
+          console.log(`[Infisical] injected '${secretKey}'`);
+        }
+        console.log('process.env', process.env);
+        break;
+      }
+      default:
+        break;
+    }
+
+    return ref;
+  } catch (error) {
+    if (!options?.silent) {
+      throw error;
+    }
+
+    console.error('Failed to initialize Infisical SDK');
+
+    if (error instanceof Error) {
+      console.error(error.message);
+      if (error.cause) {
+        console.error(error.cause);
+      }
+    }
+
+    return null;
+  }
+};

--- a/packages/core/src/secrets.ts
+++ b/packages/core/src/secrets.ts
@@ -1,0 +1,6 @@
+export {
+  type Environment,
+  EnvironmentSchema
+} from './lib/secrets/infisical.schemas';
+export { readInfisicalConfig } from './lib/secrets/read-infisical-config';
+export { withInfisical } from './lib/secrets/with-infisical';

--- a/packages/fly-node/README.md
+++ b/packages/fly-node/README.md
@@ -201,6 +201,9 @@ const response = await fly.deploy({
   environment: 'preview',
   org: 'baz',
   region: 'arn',
+  env: {
+    DEPLOY_ID: 'qwerty'
+  },
   secrets: {
     LICENCE_KEY: '1234567890'
   }

--- a/packages/fly-node/src/lib/fly.class.spec.ts
+++ b/packages/fly-node/src/lib/fly.class.spec.ts
@@ -895,13 +895,6 @@ describe('Fly', () => {
     });
 
     it('should create app with name from provided config file and deploy with the same config', async () => {
-      // setupFlyMocks([
-      //   {
-      //     cmdMatch: /config show/,
-      //     resolveOrReject: 'resolve',
-      //     output: JSON.stringify(mockShowConfigResponse('config-app'))
-      //   }
-      // ]);
       const fly = new Fly(defaultFlyConfig);
       const response = await fly.deploy({
         config: mockDefs.newConfig
@@ -967,6 +960,25 @@ describe('Fly', () => {
 
       expect(mockExec).toHaveBeenCalledWith(
         expect.stringMatching(/deploy .* DEPLOY_ENV=production/)
+      );
+    });
+
+    it('should set environment variables', async () => {
+      const fly = new Fly(defaultFlyConfig);
+      await fly.deploy({
+        app: mockDefs.testApp,
+        config: mockDefs.testConfig,
+        env: {
+          TEST_ENV: 'value',
+          WITH_BACKSLASH: 'value\\with\\backslash',
+          WITH_SPACE: 'value with space'
+        }
+      });
+
+      expect(mockExec).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /deploy .* --env TEST_ENV=value --env WITH_BACKSLASH=value\\\\with\\\\backslash --env WITH_SPACE=value\\ with\\ space/
+        )
       );
     });
 

--- a/packages/fly-node/src/lib/fly.class.ts
+++ b/packages/fly-node/src/lib/fly.class.ts
@@ -585,6 +585,9 @@ export class Fly {
     if (options?.environment) {
       args.push('--env', `DEPLOY_ENV=${options.environment}`);
     }
+    for (const [key, value] of Object.entries(options?.env || {})) {
+      args.push('--env', `${key}=${this.safeArg(value)}`);
+    }
     args.push('--yes');
 
     this.logger.info(`Deploying '${appName}'...`);
@@ -624,7 +627,7 @@ export class Fly {
       args.push('--stage');
     }
     for (const [key, value] of Object.entries(secrets)) {
-      args.push(`${key}=${value.replace(/\\/g, '\\\\').replace(/ /g, '\\ ')}`);
+      args.push(`${key}=${this.safeArg(value)}`);
     }
 
     await this.execFly(args);
@@ -1132,6 +1135,16 @@ ${error}`);
     const config = 'config' in options && options.config ? options.config : '';
 
     return { app, config };
+  }
+
+  /**
+   * Escape an argument for Fly cli
+   *
+   * @param arg - The argument to escape
+   * @returns The escaped argument
+   */
+  private safeArg(arg: string): string {
+    return arg.replace(/\\/g, '\\\\').replace(/ /g, '\\ ');
   }
 
   /**

--- a/packages/fly-node/src/lib/types.ts
+++ b/packages/fly-node/src/lib/types.ts
@@ -165,19 +165,14 @@ export type DeployAppOptions = {
   config?: string;
 
   /**
+   * Environment variables to set for the application.
+   *
+   * Spaces are supported in values.
+   */
+  env?: Record<string, string>;
+
+  /**
    * Target environment for the application.
-   *
-   * TODO Move the idea of environment to the action
-   *
-   * When value is `'production'` the options `app` and `config` will decide how the application is deployed.
-   * This is the normal deployment flow.
-   *
-   * But when value is something else the application will be deployed to a **preview** environment,
-   * with a name according to the provided value.
-   *
-   * There is only **one** opinionated difference between the two deployment flows:
-   * - When deploying to a **preview** environment, a new name will be generated
-   * unless a unique `app` name is provided
    *
    * Environment variable `DEPLOY_ENV` will be set to the provided value.
    *

--- a/packages/nx-fly-deployment-action/README.md
+++ b/packages/nx-fly-deployment-action/README.md
@@ -56,11 +56,40 @@ This action will manage deployments to [Fly.io](https://fly.io) of your [Nx](htt
     token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
+### Determine environment
+
+The environment to deploy to is determined by the event type and branch name.
+
+**Pull requests** are deployed to a **preview** environment.
+
+**Push events** on the `main` branch are deployed to the **production** environment.
+
+> [!TIP]
+> The environment is also set in the `DEPLOY_ENV` environment variable for the deployed applications
+
+## Inputs
+
+See [action.yaml](action.yml) for descriptions of the inputs.
+
+### Additional input details
+
+`secrets`
+
+The secrets are passed to the deployed applications as Fly secrets. All secrets are passed to all applications.
+
+Provide the secrets as multiline key/value strings.
+
+```yaml
+- uses: ./packages/nx-fly-deployment-action
+  with:
+    secrets: |
+      SECRET_KEY1=secret-value1
+      SECRET_KEY2=secret-value2
+```
+
+> [!NOTE]
+> The same pattern also applies to `env` input.
+
 ### Outputs
 
-The action will output the following variables:
-
-- `environment`: The environment used for deployment.
-- `destroyed`: A list of project names that were destroyed.
-- `skipped`: A list of project names that were skipped for some reason.
-- `deployed`: JSON object containing the deployed project names and their urls.
+See [action.yaml](action.yml) for descriptions of the outputs.

--- a/packages/nx-fly-deployment-action/action.yml
+++ b/packages/nx-fly-deployment-action/action.yml
@@ -20,6 +20,16 @@ inputs:
     description: >
       The main branch name.
       Defaults to the default branch of the repository.
+  env:
+    description: >
+      A multiline string of environment variables to set for the application.
+      Each variable should be on a new line in the format of `KEY=VALUE`.
+      Defaults to an empty string.
+  secrets:
+    description: >
+      A multiline string of secrets to pass to the deployed applications.
+      Each secret should be on a new line in the format of `KEY=VALUE`.
+      Defaults to an empty string.
   token:
     description: >
       The token to use for repository authentication.

--- a/packages/nx-fly-deployment-action/src/lib/__snapshots__/schemas.spec.ts.snap
+++ b/packages/nx-fly-deployment-action/src/lib/__snapshots__/schemas.spec.ts.snap
@@ -2,10 +2,18 @@
 
 exports[`Fly Deployment Action schema validation > validates all schemas against fixtures > ActionInputsSchema transformed shape 1`] = `
 {
+  "env": [
+    "ENV_KEY1=env-value1",
+    "ENV_KEY2=env-value2",
+  ],
   "flyApiToken": "fly-token",
   "flyOrg": "company",
   "flyRegion": "sea",
   "mainBranch": "main",
+  "secrets": [
+    "SECRET_KEY1=secret-value1",
+    "SECRET_KEY2=secret-value2",
+  ],
   "token": "github-token",
 }
 `;
@@ -46,6 +54,10 @@ exports[`Fly Deployment Action schema validation > validates all schemas against
     "token": "fly-token",
   },
   "mainBranch": "main",
+  "secrets": {
+    "SECRET_KEY1": "secret-value1",
+    "SECRET_KEY2": "secret-value2",
+  },
   "token": "github-token",
 }
 `;

--- a/packages/nx-fly-deployment-action/src/lib/main.spec.ts
+++ b/packages/nx-fly-deployment-action/src/lib/main.spec.ts
@@ -19,6 +19,7 @@ vi.mock('./fly-deployment');
 describe('main', () => {
   const getBooleanInputMock = vi.spyOn(core, 'getBooleanInput');
   const getInputMock = vi.spyOn(core, 'getInput');
+  const getMultilineInputMock = vi.spyOn(core, 'getMultilineInput');
   const setFailedMock = vi.spyOn(core, 'setFailed');
   const setOutputMock = vi.spyOn(core, 'setOutput');
 
@@ -31,6 +32,7 @@ describe('main', () => {
     // Default mock values
     getBooleanInputMock.mockImplementation(() => true);
     getInputMock.mockImplementation((name: string) => name);
+    getMultilineInputMock.mockImplementation(() => []);
   });
 
   it('should run without exceptions', async () => {
@@ -47,10 +49,12 @@ describe('main', () => {
     await main.run();
 
     expect(flyDeploymentMock).toHaveBeenCalledWith({
-      mainBranch: 'main-branch',
+      env: [],
       flyApiToken: 'fly-api-token',
       flyOrg: 'fly-org',
       flyRegion: 'fly-region',
+      mainBranch: 'main-branch',
+      secrets: [],
       token: 'token'
     } satisfies ActionInputs);
     expect(runMock).toHaveReturned();
@@ -68,10 +72,12 @@ describe('main', () => {
     await main.run();
 
     expect(flyDeploymentMock).toHaveBeenCalledWith({
+      env: [],
       flyApiToken: '',
       flyOrg: '',
       flyRegion: '',
       mainBranch: '',
+      secrets: [],
       token: 'token'
     } satisfies ActionInputs);
     expect(runMock).toHaveReturned();

--- a/packages/nx-fly-deployment-action/src/lib/main.ts
+++ b/packages/nx-fly-deployment-action/src/lib/main.ts
@@ -12,10 +12,12 @@ import {
 export async function run(): Promise<void> {
   try {
     const inputs = ActionInputsSchema.parse({
+      env: core.getMultilineInput('env'),
       flyApiToken: core.getInput('fly-api-token'),
       flyOrg: core.getInput('fly-org'),
       flyRegion: core.getInput('fly-region'),
       mainBranch: core.getInput('main-branch'),
+      secrets: core.getMultilineInput('secrets'),
       token: core.getInput('token', { required: true })
     } satisfies ActionInputs);
 

--- a/packages/nx-fly-deployment-action/src/lib/schemas/__fixtures__/action-inputs.json
+++ b/packages/nx-fly-deployment-action/src/lib/schemas/__fixtures__/action-inputs.json
@@ -3,5 +3,7 @@
   "flyOrg": "company",
   "flyRegion": "sea",
   "mainBranch": "main",
+  "env": ["ENV_KEY1=env-value1", "ENV_KEY2=env-value2"],
+  "secrets": ["SECRET_KEY1=secret-value1", "SECRET_KEY2=secret-value2"],
   "token": "github-token"
 }

--- a/packages/nx-fly-deployment-action/src/lib/schemas/__fixtures__/deployment-config.json
+++ b/packages/nx-fly-deployment-action/src/lib/schemas/__fixtures__/deployment-config.json
@@ -6,5 +6,9 @@
     "region": "sea"
   },
   "mainBranch": "main",
+  "secrets": {
+    "SECRET_KEY1": "secret-value1",
+    "SECRET_KEY2": "secret-value2"
+  },
   "token": "github-token"
 }

--- a/packages/nx-fly-deployment-action/src/lib/schemas/action-inputs.schema.ts
+++ b/packages/nx-fly-deployment-action/src/lib/schemas/action-inputs.schema.ts
@@ -1,10 +1,12 @@
 import { z } from 'zod';
 
 export const ActionInputsSchema = z.object({
+  env: z.array(z.string()),
   flyApiToken: z.string(),
   flyOrg: z.string(),
   flyRegion: z.string(),
   mainBranch: z.string(),
+  secrets: z.array(z.string()),
   token: z.string().min(1, 'A GitHub token is required')
 });
 

--- a/packages/nx-fly-deployment-action/src/lib/schemas/context.schema.ts
+++ b/packages/nx-fly-deployment-action/src/lib/schemas/context.schema.ts
@@ -16,9 +16,10 @@ const BasePreviewSchema = z.object({
   })
 });
 
-// 'production' environment requires no additional fields
+// 'production' environment may have secrets
 const BaseProductionSchema = z.object({
-  environment: z.literal(EnvironmentSchema.enum.production)
+  environment: z.literal(EnvironmentSchema.enum.production),
+  secrets: z.record(z.string(), z.string()).optional()
 });
 
 // Should be used to validate `BuildingContext` data
@@ -40,6 +41,7 @@ export type Context = z.infer<typeof ContextSchema>;
 
 // Context builder helper types
 type BasePreview = z.infer<typeof BasePreviewSchema>;
+type BaseProduction = z.infer<typeof BaseProductionSchema>;
 
 /**
  * A type that is a subset of `Context` and should be used
@@ -51,5 +53,7 @@ export type BuildingContext = PrettyPartial<
   {
     action: Exclude<Action, 'skip'>;
     environment: Environment;
-  } & Pick<BasePreview, 'pullRequest'>
+    env?: Record<string, string>;
+  } & Pick<BasePreview, 'pullRequest'> &
+    Pick<BaseProduction, 'secrets'>
 >;

--- a/packages/nx-fly-deployment-action/src/lib/schemas/deployment-config.schema.ts
+++ b/packages/nx-fly-deployment-action/src/lib/schemas/deployment-config.schema.ts
@@ -3,12 +3,14 @@ import { z } from 'zod';
 import { ActionInputsSchema } from './action-inputs.schema';
 
 export const DeploymentConfigSchema = z.object({
+  env: z.record(z.string(), z.string()).optional(),
   fly: z.object({
     token: z.string().min(1, 'Fly API token is required'),
     org: z.string(),
     region: z.string()
   }),
   mainBranch: z.string().min(1, 'main branch is required'),
+  secrets: z.record(z.string(), z.string()).optional(),
   token: ActionInputsSchema.shape.token
 });
 

--- a/packages/nx-fly-deployment-action/src/lib/utils/get-deployment-config.ts
+++ b/packages/nx-fly-deployment-action/src/lib/utils/get-deployment-config.ts
@@ -7,6 +7,21 @@ import {
   DeploymentConfigSchema
 } from '../schemas/deployment-config.schema';
 
+const arrayToRecord = (
+  arr: Array<string>
+): Record<string, string> | undefined =>
+  arr.length
+    ? arr
+        .map((secret) => secret.split('='))
+        .reduce(
+          (acc, [key, value]) => {
+            acc[key] = value;
+            return acc;
+          },
+          {} as Record<string, string>
+        )
+    : undefined;
+
 /**
  * Get deployment configuration from action inputs.
  *
@@ -21,10 +36,12 @@ export const getDeploymentConfig = async (
   inputs: ActionInputs
 ): Promise<DeploymentConfig> => {
   const {
+    env: envInput,
     flyApiToken,
     flyOrg,
     flyRegion,
     mainBranch: mainBranchInput,
+    secrets: secretsInput,
     token
   } = inputs;
 
@@ -32,13 +49,21 @@ export const getDeploymentConfig = async (
   const mainBranch =
     mainBranchInput || (await getRepositoryDefaultBranch(token));
 
+  // Parse environment variables from input
+  const env = arrayToRecord(envInput);
+
+  // Parse secrets from input
+  const secrets = arrayToRecord(secretsInput);
+
   const config: DeploymentConfig = {
+    env,
     fly: {
       token: flyApiToken || process.env['FLY_API_TOKEN'] || '',
       org: flyOrg,
       region: flyRegion
     },
     mainBranch,
+    secrets,
     token
   };
   core.info(JSON.stringify(config, null, 2));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@hono/node-server':
         specifier: ^1.13.7
         version: 1.13.7(hono@4.6.12)
+      '@infisical/sdk':
+        specifier: ^3.0.4
+        version: 3.0.4
       '@octokit/request-error':
         specifier: ^5.0.1
         version: 5.1.0
@@ -2694,6 +2697,9 @@ packages:
     resolution: {integrity: sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==}
     engines: {node: '>=18.18'}
 
+  '@infisical/sdk@3.0.4':
+    resolution: {integrity: sha512-B7j5VkeQ+CsFRJnd6eNNkbjrWrzafe0CRU6og3AoY9wBub1DUQpt6ThiS+PGcuC/186qRrPYJxuJBr1nKWW95w==}
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -5262,6 +5268,10 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
+  aws-sdk@2.1311.0:
+    resolution: {integrity: sha512-X3cFNsfs3HUfz6LKiLqvDTO4EsqO5DnNssh9SOoxhwmoMyJ2et3dEmigO6TaA44BjVNdLW98+sXJVPTGvINY1Q==}
+    engines: {node: '>= 10.0.0'}
+
   aws-sign2@0.7.0:
     resolution: {integrity: sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==}
 
@@ -5476,6 +5486,9 @@ packages:
   buffer-writer@2.0.0:
     resolution: {integrity: sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==}
     engines: {node: '>=4'}
+
+  buffer@4.9.2:
+    resolution: {integrity: sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==}
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
@@ -6906,6 +6919,10 @@ packages:
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
 
+  events@1.1.1:
+    resolution: {integrity: sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==}
+    engines: {node: '>=0.4.x'}
+
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
@@ -7722,6 +7739,9 @@ packages:
     resolution: {integrity: sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==}
     engines: {node: '>=4'}
 
+  ieee754@1.1.13:
+    resolution: {integrity: sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==}
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -8301,6 +8321,10 @@ packages:
   jiti@2.4.1:
     resolution: {integrity: sha512-yPBThwecp1wS9DmoA4x4KR2h3QoslacnDR8ypuFM962kI4/456Iy1oHx2RAgh4jfZNdn0bctsdadceiBUgpU1g==}
     hasBin: true
+
+  jmespath@0.16.0:
+    resolution: {integrity: sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==}
+    engines: {node: '>= 0.6.0'}
 
   joi@17.9.2:
     resolution: {integrity: sha512-Itk/r+V4Dx0V3c7RLFdRh12IOjySm2/WGPMubBT92cQvRfYZhPM2W0hZlctjj72iES8jsRCwp7S/cRmWBnJ4nw==}
@@ -10277,6 +10301,9 @@ packages:
   pumpify@1.5.1:
     resolution: {integrity: sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==}
 
+  punycode@1.3.2:
+    resolution: {integrity: sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -10303,6 +10330,11 @@ packages:
   qs@6.4.1:
     resolution: {integrity: sha512-LQy1Q1fcva/UsnP/6Iaa4lVeM49WiOitu2T4hZCyA/elLKu37L99qcBJk4VCCk+rdLvnMzfKyiN3SZTqdAZGSQ==}
     engines: {node: '>=0.6'}
+
+  querystring@0.2.0:
+    resolution: {integrity: sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==}
+    engines: {node: '>=0.4.x'}
+    deprecated: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
 
   querystringify@2.2.0:
     resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
@@ -10820,6 +10852,9 @@ packages:
     resolution: {integrity: sha512-Q4fOxRfhmv3sqCLoGfvrC9pRV8btc0UtqL9mN6Yrv6Qi9ScL55CVH1vlPP863ISLEEMNLLuu9P+enCeGHlnzhA==}
     engines: {node: '>=14.0.0'}
     hasBin: true
+
+  sax@1.2.1:
+    resolution: {integrity: sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==}
 
   sax@1.4.1:
     resolution: {integrity: sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==}
@@ -11891,6 +11926,9 @@ packages:
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
+  url@0.10.3:
+    resolution: {integrity: sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==}
+
   urlpattern-polyfill@10.0.0:
     resolution: {integrity: sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==}
 
@@ -11934,6 +11972,10 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    hasBin: true
+
+  uuid@8.0.0:
+    resolution: {integrity: sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==}
     hasBin: true
 
   uuid@8.3.2:
@@ -12348,6 +12390,13 @@ packages:
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
+
+  xml2js@0.4.19:
+    resolution: {integrity: sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==}
+
+  xmlbuilder@9.0.7:
+    resolution: {integrity: sha512-7YXTQc3P2l9+0rjaUbLwMKRhtmwg1M1eDf6nag7urC7pIPYLD9W/jmzQ4ptRSUbodw5S0jfoGTflLemQibSpeQ==}
+    engines: {node: '>=4.0'}
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
@@ -14966,6 +15015,15 @@ snapshots:
   '@humanwhocodes/retry@0.3.1': {}
 
   '@humanwhocodes/retry@0.4.1': {}
+
+  '@infisical/sdk@3.0.4':
+    dependencies:
+      aws-sdk: 2.1311.0
+      axios: 1.7.8
+      typescript: 5.7.2
+      zod: 3.23.8
+    transitivePeerDependencies:
+      - debug
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -18719,6 +18777,19 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.0.0
 
+  aws-sdk@2.1311.0:
+    dependencies:
+      buffer: 4.9.2
+      events: 1.1.1
+      ieee754: 1.1.13
+      jmespath: 0.16.0
+      querystring: 0.2.0
+      sax: 1.2.1
+      url: 0.10.3
+      util: 0.12.5
+      uuid: 8.0.0
+      xml2js: 0.4.19
+
   aws-sign2@0.7.0: {}
 
   aws4@1.13.2: {}
@@ -18993,6 +19064,12 @@ snapshots:
   buffer-from@1.1.2: {}
 
   buffer-writer@2.0.0: {}
+
+  buffer@4.9.2:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+      isarray: 1.0.0
 
   buffer@5.7.1:
     dependencies:
@@ -20613,6 +20690,8 @@ snapshots:
 
   eventemitter3@4.0.7: {}
 
+  events@1.1.1: {}
+
   events@3.3.0: {}
 
   execa@5.1.1:
@@ -21629,6 +21708,8 @@ snapshots:
     dependencies:
       harmony-reflect: 1.6.2
 
+  ieee754@1.1.13: {}
+
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
@@ -22336,6 +22417,8 @@ snapshots:
   jiti@1.21.6: {}
 
   jiti@2.4.1: {}
+
+  jmespath@0.16.0: {}
 
   joi@17.9.2:
     dependencies:
@@ -24884,6 +24967,8 @@ snapshots:
       inherits: 2.0.4
       pump: 2.0.1
 
+  punycode@1.3.2: {}
+
   punycode@2.3.1: {}
 
   pure-rand@6.1.0: {}
@@ -24905,6 +24990,8 @@ snapshots:
       side-channel: 1.0.6
 
   qs@6.4.1: {}
+
+  querystring@0.2.0: {}
 
   querystringify@2.2.0: {}
 
@@ -25453,6 +25540,8 @@ snapshots:
       source-map-js: 1.2.1
     optionalDependencies:
       '@parcel/watcher': 2.5.0
+
+  sax@1.2.1: {}
 
   sax@1.4.1: {}
 
@@ -26718,6 +26807,11 @@ snapshots:
       querystringify: 2.2.0
       requires-port: 1.0.0
 
+  url@0.10.3:
+    dependencies:
+      punycode: 1.3.2
+      querystring: 0.2.0
+
   urlpattern-polyfill@10.0.0: {}
 
   use-context-selector@1.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.23.2):
@@ -26750,6 +26844,8 @@ snapshots:
   utils-merge@1.0.1: {}
 
   uuid@10.0.0: {}
+
+  uuid@8.0.0: {}
 
   uuid@8.3.2: {}
 
@@ -27302,6 +27398,13 @@ snapshots:
   xml-name-validator@4.0.0: {}
 
   xml-name-validator@5.0.0: {}
+
+  xml2js@0.4.19:
+    dependencies:
+      sax: 1.4.1
+      xmlbuilder: 9.0.7
+
+  xmlbuilder@9.0.7: {}
 
   xmlchars@2.2.0: {}
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -18,6 +18,7 @@
     "paths": {
       "@codeware/core/actions": ["packages/core/src/actions.ts"],
       "@codeware/core/release": ["packages/core/src/release.ts"],
+      "@codeware/core/secrets": ["packages/core/src/secrets.ts"],
       "@codeware/core/testing": ["packages/core/src/testing.ts"],
       "@codeware/core/utils": ["packages/core/src/utils.ts"],
       "@codeware/core/zod": ["packages/core/src/zod.ts"],


### PR DESCRIPTION
- `core` - add Infisical support to any app using `withInfisical` function
- `fly-node` - provide custom env variables when deploying an app
- `nx-fly-deployment-action` - provide custom env variables and secrets
- `web` - using `withInfisical` to inject secrets depending on `DEPLOY_ENV` and `TENANT_ID`

**In practice**

All deployments add 
- env
  - `DEPLOY_ENV` to ether `preview` or `production`
  - `TENANT_ID` to `default` (for now) 
- secret
  - `INFISICAL_CLIENT_ID` with value from `secrets.INFISICAL_READ_CLIENT_ID`
  - `INFISICAL_CLIENT_SECRET` with value from `secrets.INFISICAL_READ_CLIENT_SECRET`

Refactored web config a bit to be more Nx friendly and to support caching.

After developer is logged in to Infisical CLI and runs `nx start web` all secrets for `default` tenant should be inhected into `process.env`.