### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -12,6 +12,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # Environment details:
 # - renovate branches should never use Nx Cloud
 env:


### PR DESCRIPTION
Potential fix for [https://github.com/codeware-sthlm/codeware/security/code-scanning/8](https://github.com/codeware-sthlm/codeware/security/code-scanning/8)

To resolve the issue, add an explicit `permissions` block to the workflow file. Place this block at the top workflow level (after `name:` and `on:`), so it applies to all jobs by default. Since the jobs only require access to check out the source code and upload/download artifacts (which do not require write access to the repository), the minimum required is `contents: read`. If none of the jobs require `write` access to issues, pull-requests, or other resources, there is no need to add further permissions. If future jobs need broader access, their permissions can be overridden at the job level.  

**Steps:**
- Insert a `permissions:` section after the `on:` block (before `env:` or any other top-level keys).
- Set it to `contents: read`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
