### PR TITLE
fix(nx-payload): fix gen target path and bump Payload to 3.84.1

### DIFF
--- a/packages/nx-payload/README.md
+++ b/packages/nx-payload/README.md
@@ -22,7 +22,6 @@
 
 - [Prerequisites](#prerequisites)
 - [Next.js Version](#nextjs-version)
-- [Known Payload issue](#known-payload-issue)
 - [Installation](#installation)
   - [Add Payload plugin to an existing workspace](#add-payload-plugin-to-an-existing-workspace)
   - [Inferred tasks](#inferred-tasks)
@@ -88,20 +87,6 @@ If you intentionally want to use Next.js v16, ensure it's installed before addin
 
 > [!TIP]
 > See [this Payload PR](https://github.com/payloadcms/payload/pull/14456) related to their work on supporting Next.js v16
-
-## Known Payload issue
-
-There is a known Payload issue that affects generate commands. The ticket [found here](https://github.com/payloadcms/payload/issues/13290) is closed without fixing the core issue, originally inferred by the Undici dependency. Though this ticket targets pnpm workspace, it looks like it affects all package managers.
-
-**Workaround options**
-
-- Pin your Payload version to 3.42
-- Convert to a module workspace by setting `type` in `package.json` to `"module"` (recommended)
-
-> [!NOTE]
-> This library will pin Payload version to **3.42** for **new installations** when a CommonJS workspace is detected.
->
-> Then it's up to the developer to decide how to move forward.
 
 ## Installation
 
@@ -395,13 +380,9 @@ Generate a Payload application powered by Next.js.
 
 Later versions of Nx or Payload might work as well, but the versions below have been used during tests.
 
-> [!NOTE]
-> Automated tests are currently pinned to version 3.42, see [Known Payload issue](#known-payload-issue).
->
-> However, manual tests on ESM workspace have verified 3.69 as well.
-
 | Plugin    | Nx        | Payload   | React     | Next.js   |
 | --------- | --------- | --------- | --------- | --------- |
+| `^2.2.1`  | `22.x`    | `3.84.1`  | `^19.0.0` | `^15.0.0` |
 | `^2.2.0`  | `22.x`    | `~3.42.0` | `^19.0.0` | `^15.0.0` |
 | `^2.1.0`  | `21.x`    | `~3.42.0` | `^19.0.0` | `^15.0.0` |
 | `^2.0.0`  | `^20.4.2` | `^3.0.0`  | `^19.0.0` | `^15.0.0` |

--- a/packages/nx-payload/eslint.config.mjs
+++ b/packages/nx-payload/eslint.config.mjs
@@ -32,6 +32,8 @@ export default [
             '@nx/js',
             '@nx/next',
             'nx',
+            // peer dep used via type-only import; @nx/dependency-checks ignores type imports
+            'payload',
             'tslib',
             'typescript',
             'next'

--- a/packages/nx-payload/index.ts
+++ b/packages/nx-payload/index.ts
@@ -3,7 +3,4 @@ export { initGenerator } from './src/generators/init/init';
 export { presetGenerator } from './src/generators/preset/preset';
 
 export type { AppGeneratorSchema } from './src/generators/application/schema';
-export {
-  payloadCommonJSVersion,
-  payloadESMVersion
-} from './src/utils/versions';
+export { payloadVersion } from './src/utils/versions';

--- a/packages/nx-payload/src/generators/application/libs/ensure-project-targets.ts
+++ b/packages/nx-payload/src/generators/application/libs/ensure-project-targets.ts
@@ -53,7 +53,9 @@ export function ensureProjectTargets(
     projectName: options.name,
     projectRoot: options.directory,
     // graphQL is disabled by design in `payload.config.ts` template
-    isGraphQLDisabled: true
+    isGraphQLDisabled: true,
+    // src folder is always used by design in this generator
+    configFile: 'src/payload.config.ts'
   });
 
   // Apply payload targets to project config

--- a/packages/nx-payload/src/generators/init/init.spec.ts
+++ b/packages/nx-payload/src/generators/init/init.spec.ts
@@ -5,8 +5,7 @@ import type { PackageJson } from 'nx/src/utils/package-json';
 import {
   graphqlVersion,
   next15Version,
-  payloadCommonJSVersion,
-  payloadESMVersion
+  payloadVersion
 } from '../../utils/versions';
 
 import { initGenerator } from './init';
@@ -26,43 +25,20 @@ describe('init', () => {
     tree = createTreeWithEmptyWorkspace();
   });
 
-  it('should use Payload version for CommonJS workspace', async () => {
+  it('should use Payload version', async () => {
     await initGenerator(tree, options);
     const packageJson = readJson<PackageJson>(tree, 'package.json');
 
     expect(packageJson).toMatchObject({
       dependencies: {
-        '@payloadcms/db-mongodb': payloadCommonJSVersion,
-        '@payloadcms/db-postgres': payloadCommonJSVersion,
-        '@payloadcms/next': payloadCommonJSVersion,
-        '@payloadcms/richtext-lexical': payloadCommonJSVersion,
-        payload: payloadCommonJSVersion
+        '@payloadcms/db-mongodb': payloadVersion,
+        '@payloadcms/db-postgres': payloadVersion,
+        '@payloadcms/next': payloadVersion,
+        '@payloadcms/richtext-lexical': payloadVersion,
+        payload: payloadVersion
       },
       devDependencies: {
-        '@payloadcms/graphql': payloadCommonJSVersion
-      }
-    });
-  });
-
-  it('should use Payload version for ESM workspaces', async () => {
-    const packageJsonESM = readJson<PackageJson>(tree, 'package.json');
-    packageJsonESM.type = 'module';
-    tree.write('package.json', JSON.stringify(packageJsonESM, null, 2));
-
-    await initGenerator(tree, options);
-
-    const packageJson = readJson<PackageJson>(tree, 'package.json');
-
-    expect(packageJson).toMatchObject({
-      dependencies: {
-        '@payloadcms/db-mongodb': payloadESMVersion,
-        '@payloadcms/db-postgres': payloadESMVersion,
-        '@payloadcms/next': payloadESMVersion,
-        '@payloadcms/richtext-lexical': payloadESMVersion,
-        payload: payloadESMVersion
-      },
-      devDependencies: {
-        '@payloadcms/graphql': payloadESMVersion
+        '@payloadcms/graphql': payloadVersion
       }
     });
   });

--- a/packages/nx-payload/src/generators/init/libs/update-dependencies.ts
+++ b/packages/nx-payload/src/generators/init/libs/update-dependencies.ts
@@ -1,14 +1,10 @@
-import { type Tree, addDependenciesToPackageJson, readJson } from '@nx/devkit';
-import {
-  PackageJson,
-  getDependencyVersionFromPackageJson
-} from 'nx/src/utils/package-json';
+import { type Tree, addDependenciesToPackageJson } from '@nx/devkit';
+import { getDependencyVersionFromPackageJson } from 'nx/src/utils/package-json';
 
 import {
   graphqlVersion,
   next15Version,
-  payloadCommonJSVersion,
-  payloadESMVersion
+  payloadVersion
 } from '../../../utils/versions';
 
 /**
@@ -25,24 +21,19 @@ export function updateDependencies(tree: Tree) {
     nextDep = { next: next15Version };
   }
 
-  const version =
-    readJson<PackageJson>(tree, 'package.json').type === 'module'
-      ? payloadESMVersion
-      : payloadCommonJSVersion;
-
   return addDependenciesToPackageJson(
     tree,
     {
-      '@payloadcms/db-mongodb': version,
-      '@payloadcms/db-postgres': version,
-      '@payloadcms/next': version,
-      '@payloadcms/richtext-lexical': version,
+      '@payloadcms/db-mongodb': payloadVersion,
+      '@payloadcms/db-postgres': payloadVersion,
+      '@payloadcms/next': payloadVersion,
+      '@payloadcms/richtext-lexical': payloadVersion,
       ...nextDep,
-      payload: version,
+      payload: payloadVersion,
       graphql: graphqlVersion
     },
     {
-      '@payloadcms/graphql': version
+      '@payloadcms/graphql': payloadVersion
     }
   );
 }

--- a/packages/nx-payload/src/plugins/utils/create-payload-nodes.ts
+++ b/packages/nx-payload/src/plugins/utils/create-payload-nodes.ts
@@ -78,11 +78,15 @@ export const createPayloadNodes = async (
     ]
   );
 
+  // Path to the Payload config file relative to the project root
+  const configFile = relative(projectRoot, configFilePath);
+
   // Get payload targets to be inferred for the project
   targetsCache[hash] ??= createPayloadTargets({
     isGraphQLDisabled: graphQLDisabled,
     projectName: String(projectName), // Should have a value by design?
-    projectRoot
+    projectRoot,
+    configFile
   });
 
   return {

--- a/packages/nx-payload/src/utils/create-payload-targets.ts
+++ b/packages/nx-payload/src/utils/create-payload-targets.ts
@@ -13,8 +13,9 @@ export function createPayloadTargets(args: {
   isGraphQLDisabled?: boolean;
   projectName: string;
   projectRoot: string;
+  configFile: string;
 }): Record<PayloadTarget, TargetConfiguration> {
-  const { isGraphQLDisabled, projectName, projectRoot } = args;
+  const { isGraphQLDisabled, projectName, projectRoot, configFile } = args;
 
   const dxPrefix = 'Developer experience (DX)';
 
@@ -26,7 +27,7 @@ export function createPayloadTargets(args: {
         technologies: ['node']
       },
       executor: 'nx:run-commands',
-      inputs: ['{projectRoot}/src/payload.config.ts'],
+      inputs: [`{projectRoot}/${configFile}`],
       options: {
         commands: isGraphQLDisabled
           ? ['npx payload generate:types']
@@ -35,6 +36,7 @@ export function createPayloadTargets(args: {
               'npx payload-graphql generate:schema'
             ],
         cwd: projectRoot,
+        env: { PAYLOAD_CONFIG_PATH: configFile },
         parallel: false
       } satisfies Partial<RunCommandsOptions>
     },
@@ -47,7 +49,8 @@ export function createPayloadTargets(args: {
       options: {
         command: 'npx payload',
         forwardAllArgs: true,
-        cwd: projectRoot
+        cwd: projectRoot,
+        env: { PAYLOAD_CONFIG_PATH: configFile }
       } satisfies Partial<RunCommandsOptions>
     },
     'payload-graphql': {
@@ -59,7 +62,8 @@ export function createPayloadTargets(args: {
       options: {
         command: 'npx payload-graphql',
         forwardAllArgs: true,
-        cwd: projectRoot
+        cwd: projectRoot,
+        env: { PAYLOAD_CONFIG_PATH: configFile }
       } satisfies Partial<RunCommandsOptions>
     },
     'dx:mongodb': {

--- a/packages/nx-payload/src/utils/versions.ts
+++ b/packages/nx-payload/src/utils/versions.ts
@@ -1,13 +1,4 @@
-/**
- * Payload version which is also applied to all plugins for ESM workspaces.
- */
-export const payloadESMVersion = '~3.71.0';
-
-/**
- * Undici bug require Payload to stay at version 3.42 for CommonJS workspaces.
- * https://github.com/payloadcms/payload/issues/13290
- */
-export const payloadCommonJSVersion = '~3.42.0';
+export const payloadVersion = '3.84.1';
 
 /**
  * Next 15 version to install when missing.


### PR DESCRIPTION
Fixes COD-385.

## Summary

- **Root cause**: `@nx/js` 22.7.1 introduced `ensureRelativePath` in `addTsConfigPath`, prepending `./` to the `@payload-config` tsconfig path alias. The Payload CLI running with `cwd: projectRoot` then resolved `./apps/app-default/src/payload.config.ts` relative to its working directory instead of the workspace root, producing a doubled `apps/app-default/apps/app-default/…` path.
- **Fix**: Set `PAYLOAD_CONFIG_PATH` explicitly on `gen` and `payload` targets so the Payload CLI bypasses tsconfig alias resolution entirely. `configFile` is now a required parameter on `createPayloadTargets`, with the plugin computing the actual relative path and the generator hardcoding `src/payload.config.ts` (known by design).
- **Version cleanup**: Consolidate `payloadESMVersion` / `payloadCommonJSVersion` into a single pinned `payloadVersion = '3.84.1'` — the ESM/CJS split was a workaround for an undici bug (payloadcms/payload#13290) that is no longer relevant. Remove the corresponding branch in `update-dependencies.ts` and merge the two redundant tests in `init.spec.ts`.
- **README**: Remove the stale "Known Payload issue" section and add a `^2.2.1` row to the versions compatibility table.

## Test plan

- [ ] `pnpm nx test nx-payload` passes
- [ ] `pnpm exec nx e2e nx-payload-e2e -c quick` passes (was the failing suite in COD-385)

🤖 Generated with [Claude Code](https://claude.com/claude-code)