### PR TITLE
feat(storybook): add Chromatic CI publishing and visual regression

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,56 @@
+name: Chromatic
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  statuses: write
+
+env:
+  NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+  NX_NO_CLOUD: ${{ startsWith(github.head_ref || github.ref_name, 'renovate') ||
+    github.event_name == 'push' || github.event_name == 'workflow_dispatch' ||
+    vars.NX_NO_CLOUD }}
+  NX_PARALLEL: ${{ vars.NX_PARALLEL }}
+  NX_VERBOSE_LOGGING: ${{ vars.NX_VERBOSE_LOGGING }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  chromatic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm package manager
+        uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Analyze affected projects
+        uses: nrwl/nx-set-shas@v4
+
+      - name: Publish to Chromatic
+        run: pnpm nx affected -t chromatic
+        env:
+          CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -83,4 +83,8 @@ out
 # Infisical credentials (tools)
 .env.infisical
 
+# Local environment overrides (may contain secrets)
+.env.local
+*.env.local
+
 .nx/self-healing

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,6 +18,7 @@
     "runAllTestsOnStartup": false,
     "type": "on-demand"
   },
+  "json.schemaDownload.enable": true,
   "nxConsole.generateAiAgentRules": true,
   "vitest.filesWatcherInclude": "apps/**,libs/**,packages/**",
   "[json]": {

--- a/apps/storybook/chromatic.config.json
+++ b/apps/storybook/chromatic.config.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://www.chromatic.com/config-file.schema.json",
+  "autoAcceptChanges": "main",
+  "exitZeroOnChanges": true,
+  "onlyChanged": true,
+  "storybookBuildDir": "dist/storybook"
+}

--- a/apps/storybook/project.json
+++ b/apps/storybook/project.json
@@ -31,6 +31,13 @@
         }
       },
       "syncGenerators": ["dev-plugin:theme-sync"]
+    },
+    "chromatic": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["build-storybook"],
+      "options": {
+        "command": "chromatic --no-interactive --config-file apps/storybook/chromatic.config.json"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -174,6 +174,7 @@
     "babel-jest": "30.3.0",
     "baseline-browser-mapping": "^2.8.32",
     "chalk": "^4.1.0",
+    "chromatic": "^17.5.0",
     "cli-table3": "^0.6.5",
     "concurrently": "^9.1.2",
     "create-nx-workspace": "22.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -497,6 +497,9 @@ importers:
       chalk:
         specifier: ^4.1.0
         version: 4.1.2
+      chromatic:
+        specifier: ^17.5.0
+        version: 17.5.0
       cli-table3:
         specifier: ^0.6.5
         version: 0.6.5
@@ -2901,7 +2904,6 @@ packages:
 
   '@evilmartians/lefthook@1.13.6':
     resolution: {integrity: sha512-79vplrUBWL4Fkt59YkEBdSpqBVhNrY8t5+jEp+wX5QbsmbQLcSULqwS7FmbNRyECa2LWMrUWpe6ENIfNwB4jiw==}
-    cpu: [x64, arm64, ia32]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -8929,6 +8931,22 @@ packages:
       '@chromatic-com/cypress':
         optional: true
       '@chromatic-com/playwright':
+        optional: true
+
+  chromatic@17.5.0:
+    resolution: {integrity: sha512-jYtXDaY1VeaNaWMom4HewLQTL574s4wTtkg5Kryov9Cj7D6i8Pe7twpLsetG7apxD0aITWUhx6KiqfN6p380rw==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@chromatic-com/cypress': ^0.*.* || ^1.0.0
+      '@chromatic-com/playwright': ^0.*.* || ^1.0.0
+      '@chromatic-com/vitest': ^0.*.* || ^1.0.0
+    peerDependenciesMeta:
+      '@chromatic-com/cypress':
+        optional: true
+      '@chromatic-com/playwright':
+        optional: true
+      '@chromatic-com/vitest':
         optional: true
 
   chrome-trace-event@1.0.4:
@@ -18539,7 +18557,7 @@ snapshots:
   '@commitlint/is-ignored@19.8.1':
     dependencies:
       '@commitlint/types': 19.8.1
-      semver: 7.7.3
+      semver: 7.8.0
 
   '@commitlint/lint@19.8.1':
     dependencies:
@@ -21006,7 +21024,7 @@ snapshots:
       json-parse-even-better-errors: 3.0.2
       normalize-package-data: 5.0.0
       proc-log: 3.0.0
-      semver: 7.7.3
+      semver: 7.8.0
     transitivePeerDependencies:
       - bluebird
 
@@ -25676,7 +25694,7 @@ snapshots:
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare-lite: 1.4.0
-      semver: 7.7.3
+      semver: 7.8.0
       tsutils: 3.21.0(typescript@5.9.2)
     optionalDependencies:
       typescript: 5.9.2
@@ -25796,7 +25814,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.51.0
       debug: 4.4.3(supports-color@5.5.0)
       minimatch: 9.0.5
-      semver: 7.7.3
+      semver: 7.8.0
       tinyglobby: 0.2.15
       ts-api-utils: 2.4.0(typescript@5.9.2)
       typescript: 5.9.2
@@ -27304,6 +27322,10 @@ snapshots:
 
   chromatic@13.3.5: {}
 
+  chromatic@17.5.0:
+    dependencies:
+      semver: 7.8.0
+
   chrome-trace-event@1.0.4: {}
 
   ci-info@4.3.1: {}
@@ -27653,7 +27675,7 @@ snapshots:
       postcss-modules-scope: 3.2.1(postcss@8.5.14)
       postcss-modules-values: 4.0.0(postcss@8.5.14)
       postcss-value-parser: 4.2.0
-      semver: 7.7.3
+      semver: 7.8.0
     optionalDependencies:
       '@rspack/core': 1.6.8(@swc/helpers@0.5.18)
       webpack: 5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.19.12)
@@ -29248,7 +29270,7 @@ snapshots:
       minimatch: 3.1.2
       node-abort-controller: 3.1.1
       schema-utils: 3.3.0
-      semver: 7.7.3
+      semver: 7.8.0
       tapable: 2.3.3
       typescript: 5.9.2
       webpack: 5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.19.12)
@@ -32483,7 +32505,7 @@ snapshots:
 
   node-abi@3.85.0:
     dependencies:
-      semver: 7.7.3
+      semver: 7.8.0
 
   node-abort-controller@3.1.1: {}
 
@@ -33330,7 +33352,7 @@ snapshots:
       cosmiconfig: 9.0.0(typescript@5.9.2)
       jiti: 2.6.1
       postcss: 8.5.14
-      semver: 7.7.3
+      semver: 7.8.0
     optionalDependencies:
       '@rspack/core': 1.6.8(@swc/helpers@0.5.18)
       webpack: 5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.19.12)
@@ -34630,7 +34652,7 @@ snapshots:
     dependencies:
       '@img/colour': 1.0.0
       detect-libc: 2.1.2
-      semver: 7.7.3
+      semver: 7.8.0
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.5
       '@img/sharp-darwin-x64': 0.34.5
@@ -34730,7 +34752,7 @@ snapshots:
 
   simple-update-notifier@2.0.0:
     dependencies:
-      semver: 7.7.3
+      semver: 7.8.0
 
   simple-wcswidth@1.1.2: {}
 
@@ -35478,7 +35500,7 @@ snapshots:
       chalk: 4.1.2
       enhanced-resolve: 5.21.3
       micromatch: 4.0.8
-      semver: 7.7.3
+      semver: 7.8.0
       source-map: 0.7.6
       typescript: 5.9.2
       webpack: 5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.19.12)


### PR DESCRIPTION
Closes COD-390

## Summary

- Add `chromatic@17.5.0` devDependency and `storybook:chromatic` Nx target (depends on `build-storybook`, non-blocking)
- Add `chromatic.config.json` with TurboSnap (`onlyChanged`), auto-accept on `main`, and pre-built dir config
- Add `.github/workflows/chromatic.yml` — triggers on PR + push to `main`, gated by `nx affected` so unrelated PRs don't burn snapshots

## Notes

- `CHROMATIC_PROJECT_TOKEN` must be set as a repo Actions secret before CI publishes
- `--no-interactive` on the Nx target suppresses the first-run setup prompt locally
- `merge_group` excluded — Chromatic is non-blocking so re-running in the merge queue wastes snapshots