### PR TITLE
fix(cms): load DATABASE_URL from Infisical in release_command

### DIFF
--- a/.github/workflows/fly-deployment.yml
+++ b/.github/workflows/fly-deployment.yml
@@ -61,7 +61,10 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || github.head_ref || github.ref }}
+  # Normalize the branch name across all trigger types so push and workflow_run
+  # on the same branch share one concurrency slot and cannot run simultaneously.
+  # github.ref is refs/heads/main for push; workflow_run gives head_branch=main.
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
   cancel-in-progress: false
 
 jobs:

--- a/apps/cms/src/migrate.config.ts
+++ b/apps/cms/src/migrate.config.ts
@@ -6,8 +6,7 @@ import { buildConfig } from 'payload';
 // payload and the DB adapter directly into migrate.mjs without pulling in Next.js dependencies.
 
 // Default to 'payload' — all migrations hardcode this schema via SET search_path.
-// The env-loader (Infisical) only runs in the main Next.js process, not in this
-// release-command script, so DATABASE_SCHEMA may be absent on fresh preview apps.
+// DATABASE_SCHEMA may be absent on fresh preview apps; the default is safe.
 const schemaName = process.env['DATABASE_SCHEMA'] || 'payload';
 
 export default buildConfig({

--- a/apps/cms/src/migrate.ts
+++ b/apps/cms/src/migrate.ts
@@ -1,5 +1,7 @@
 import { type Migration, getPayload } from 'payload';
 
+import { withInfisical } from '@codeware/shared/feature/infisical';
+
 import config from './migrate.config';
 import { migrations } from './migrations';
 
@@ -8,6 +10,19 @@ import { migrations } from './migrations';
 if (process.env.TENANT_ID) {
   console.log('[migrate] Tenant mode - migrations are managed by the host app');
   process.exit(0);
+}
+
+console.log('[migrate] Running migrations for cms host...');
+
+// DATABASE_URL is env-specific and loaded from Infisical at runtime by the app.
+// The release machine has the Infisical credentials as Fly secrets, so load them
+// here if DATABASE_URL isn't already set as a native Fly secret.
+if (!process.env.DATABASE_URL) {
+  await withInfisical({
+    environment: process.env['DEPLOY_ENV'],
+    filter: { path: '/apps/cms', recurse: true },
+    injectEnv: true
+  });
 }
 
 const payload = await getPayload({ config, disableOnInit: true });

--- a/apps/cms/src/migrate.ts
+++ b/apps/cms/src/migrate.ts
@@ -14,20 +14,36 @@ if (process.env.TENANT_ID) {
 
 console.log('[migrate] Running migrations for cms host...');
 
-// DATABASE_URL is env-specific and loaded from Infisical at runtime by the app.
-// The release machine has the Infisical credentials as Fly secrets, so load them
-// here if DATABASE_URL isn't already set as a native Fly secret.
-if (!process.env.DATABASE_URL) {
-  await withInfisical({
-    environment: process.env['DEPLOY_ENV'],
-    filter: { path: '/apps/cms', recurse: true },
-    injectEnv: true
-  });
-}
-
-const payload = await getPayload({ config, disableOnInit: true });
-
 try {
+  // DATABASE_URL is env-specific and loaded from Infisical at runtime by the app.
+  // The release machine has the Infisical credentials as Fly secrets, so load them
+  // here if DATABASE_URL isn't already set as a native Fly secret.
+  if (!process.env.DATABASE_URL) {
+    if (!process.env.DEPLOY_ENV) {
+      throw new Error(
+        'DEPLOY_ENV is not set — cannot load secrets from Infisical'
+      );
+    }
+    const secrets = await withInfisical({
+      environment: process.env['DEPLOY_ENV'],
+      filter: { path: '/apps/cms', recurse: true }
+    });
+
+    // Only database url is needed
+    const databaseUrl = secrets.find(
+      (s) => s.secretKey === 'DATABASE_URL'
+    )?.secretValue;
+    if (!databaseUrl) {
+      throw new Error(
+        'DATABASE_URL not available after loading from Infisical'
+      );
+    }
+    process.env.DATABASE_URL = databaseUrl;
+  }
+
+  // Build a minimal Payload instance with the same DB config as the main app,
+  // and run the migrations directly against the database
+  const payload = await getPayload({ config, disableOnInit: true });
   await payload.db.migrate({ migrations: migrations as Migration[] });
   process.exit(0);
 } catch (error) {


### PR DESCRIPTION
## Summary

- `migrate.ts` now loads `/apps/cms` secrets from Infisical when `DATABASE_URL` is absent — the Fly release machine has `INFISICAL_CLIENT_ID`/`INFISICAL_CLIENT_SECRET`/`DEPLOY_ENV` as native Fly secrets so this works without any changes to the deployment pipeline
- `fly-deployment.yml` concurrency group normalized so `push` (`github.ref = refs/heads/main`) and `workflow_run` (`head_branch = main`) on the same branch always share one slot instead of racing

Closes COD-393

## Why this wasn't caught sooner

The `release_command` was introduced in April 2026. Every deployment since has silently failed in the release machine because `DATABASE_URL` only exists in Infisical, not as a native Fly secret. The migration `20260619_211319_cod_389` (block tables) was the first one generated after that, making the failure visible via Sentry (`pages_blocks_callout` does not exist).

## Test plan

- [ ] Merge and verify the deployment completes with the release_command running successfully in Fly logs
- [ ] Confirm migration `20260619_211319_cod_389` is recorded in `payload.payload_migrations`
- [ ] Confirm Sentry issue CMS-E stops recurring