### PR TITLE
fix(cms): defer config evaluation until after DATABASE_URL is injected

### DIFF
--- a/apps/cms/src/migrate.config.ts
+++ b/apps/cms/src/migrate.config.ts
@@ -5,24 +5,29 @@ import { buildConfig } from 'payload';
 // Intentionally excludes sharp, Sentry, collections, and plugins so esbuild can bundle
 // payload and the DB adapter directly into migrate.mjs without pulling in Next.js dependencies.
 
-// Default to 'payload' — all migrations hardcode this schema via SET search_path.
-// DATABASE_SCHEMA may be absent on fresh preview apps; the default is safe.
-const schemaName = process.env['DATABASE_SCHEMA'] || 'payload';
+// Exported as a factory so migrate.ts can call it after DATABASE_URL is loaded from
+// Infisical at runtime — static imports evaluate before any top-level code runs,
+// which means process.env reads at module level would capture undefined.
+export const getConfig = () => {
+  // Default to 'payload' — all migrations hardcode this schema via SET search_path.
+  // DATABASE_SCHEMA may be absent on fresh preview apps; the default is safe.
+  const schemaName = process.env['DATABASE_SCHEMA'] || 'payload';
 
-export default buildConfig({
-  db: postgresAdapter({
-    pool: {
-      connectionString: process.env['DATABASE_URL'],
-      // pg passes `options` verbatim in the startup message, setting search_path for every
-      // connection in the pool. Without this, Drizzle's unqualified INSERT INTO
-      // "payload_migrations" resolves to public.payload_migrations which doesn't exist on
-      // fresh databases — only payload.payload_migrations exists after the first migration.
-      options: schemaName ? `-c search_path=${schemaName},public` : undefined
-    },
-    schemaName
-  }),
-  // Payload requires a non-empty secret to init, even for migrations that don't use JWT auth.
-  // The real secret is a runtime variable from Infisical; fall back to a placeholder when absent.
-  secret: process.env['PAYLOAD_SECRET_KEY'] || 'migrate-placeholder',
-  collections: []
-});
+  return buildConfig({
+    db: postgresAdapter({
+      pool: {
+        connectionString: process.env['DATABASE_URL'],
+        // pg passes `options` verbatim in the startup message, setting search_path for every
+        // connection in the pool. Without this, Drizzle's unqualified INSERT INTO
+        // "payload_migrations" resolves to public.payload_migrations which doesn't exist on
+        // fresh databases — only payload.payload_migrations exists after the first migration.
+        options: schemaName ? `-c search_path=${schemaName},public` : undefined
+      },
+      schemaName
+    }),
+    // Payload requires a non-empty secret to init, even for migrations that don't use JWT auth.
+    // The real secret is a runtime variable from Infisical; fall back to a placeholder when absent.
+    secret: process.env['PAYLOAD_SECRET_KEY'] || 'migrate-placeholder',
+    collections: []
+  });
+};

--- a/apps/cms/src/migrate.ts
+++ b/apps/cms/src/migrate.ts
@@ -2,7 +2,7 @@ import { type Migration, getPayload } from 'payload';
 
 import { withInfisical } from '@codeware/shared/feature/infisical';
 
-import config from './migrate.config';
+import { getConfig } from './migrate.config';
 import { migrations } from './migrations';
 
 // Invoked via Fly release_command before machines are updated.
@@ -42,8 +42,12 @@ try {
   }
 
   // Build a minimal Payload instance with the same DB config as the main app,
-  // and run the migrations directly against the database
-  const payload = await getPayload({ config, disableOnInit: true });
+  // and run the migrations directly against the database.
+  // getConfig() is called here (not at import time) so DATABASE_URL is already set.
+  const payload = await getPayload({
+    config: getConfig(),
+    disableOnInit: true
+  });
   await payload.db.migrate({ migrations: migrations as Migration[] });
   process.exit(0);
 } catch (error) {

--- a/apps/storybook/src/Introduction.mdx
+++ b/apps/storybook/src/Introduction.mdx
@@ -4,6 +4,8 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 # Design System
 
+> **Hosted reference:** [Browse on Chromatic](https://main--6a3651992b1c29d22c5357dc.chromatic.com) · [Component index (JSON)](https://main--6a3651992b1c29d22c5357dc.chromatic.com/index.json)
+
 This Storybook covers the UI and theming layer for the Codeware platform. Two concerns live here:
 
 - **Dashboard components** — `libs/app-cms/ui/dashboard`. Purpose-built components for Payload CMS admin customizations: cards, banners, modals, buttons, form inputs.


### PR DESCRIPTION
## Summary

- `migrate.config.ts` was a static import — ES modules evaluate all static imports before any top-level code runs, so `process.env['DATABASE_URL']` was read before Infisical could inject it. `postgresAdapter` captured `undefined` as the connection string, causing `pg.Pool` to default to `localhost:5432`.
- Fixed by exporting `getConfig()` factory function from `migrate.config.ts` and calling it in the `try` block in `migrate.ts`, after `DATABASE_URL` is set.

This was the actual cause of the `ECONNREFUSED 127.0.0.1:5432` error seen in the production deployment from PR #436.

Closes COD-393

## Test plan

- [ ] Merge and verify release_command completes without connection errors in Fly deploy logs
- [ ] Confirm migration `20260619_211319_cod_389` recorded in `payload.payload_migrations`
- [ ] Confirm Sentry `pages_blocks_callout` error stops recurring