### PR TITLE
fix(workflow): sentry cleanup and notify skipped on build failure

### DIFF
--- a/.github/workflows/fly-deployment.yml
+++ b/.github/workflows/fly-deployment.yml
@@ -252,7 +252,7 @@ jobs:
       # Clean up the Sentry release if the build failed.
       - name: Delete Sentry release on build failure
         if: >-
-          env.SENTRY_ORG != '' && steps.sentry-release.outcome == 'success' &&
+          always() && env.SENTRY_ORG != '' && steps.sentry-release.outcome == 'success' &&
           steps.build.outcome != 'success'
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.INF_SENTRY_AUTH_TOKEN }}
@@ -426,10 +426,10 @@ jobs:
           token: ${{ steps.generate-token.outputs.token }}
 
   notify:
-    needs: [pre-deploy, deploy]
+    needs: [pre-deploy, build, deploy]
     if: >-
       always() &&
-      needs.deploy.result != 'skipped'
+      needs.build.result != 'skipped'
     runs-on: ubuntu-latest
     steps:
       - name: Resolve PR number


### PR DESCRIPTION
Fixes COD-396

## Summary

Two steps/jobs in `fly-deployment.yml` were silently skipped when the `build` job failed, observed in https://github.com/codeware-sthlm/codeware/actions/runs/28422559512.

- **`Delete Sentry release on build failure` step** — missing `always()` in the `if` condition. GitHub Actions skips subsequent steps by default when a previous step fails unless the condition includes a status check function. Without it the cleanup never ran, leaving a dangling unfinalized Sentry release.
- **`notify` job** — gated on `needs.deploy.result != 'skipped'`, but `deploy` is always skipped when `build` fails. Added `build` to `needs` and changed the gate to `needs.build.result != 'skipped'` so Slack notifications fire on build failures too.

## Test plan

- [ ] Trigger a build that fails and verify "Delete Sentry release on build failure" runs and the Sentry release is cleaned up
- [ ] Verify a Slack notification is sent on build failure