### PR TITLE
ci: distribute CI checks across Nx Agents (cost-aware cloud)

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -16,11 +16,16 @@ permissions:
   contents: read
   statuses: write
 
+# Environment details:
+# - Nx Cloud cache is used for human-driven runs: PRs, pushes to main, and
+#   manual workflow_dispatch.
+# - Disabled only for machine-driven runs — renovate branches (matched on push
+#   and PR via head_ref/ref_name) — or via the NX_NO_CLOUD repo variable, to
+#   keep costs down on high-frequency bot traffic. (Matches ci.yml.)
 env:
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
   NX_NO_CLOUD: ${{ startsWith(github.head_ref || github.ref_name, 'renovate') ||
-    github.event_name == 'push' || github.event_name == 'workflow_dispatch' ||
-    vars.NX_NO_CLOUD }}
+    vars.NX_NO_CLOUD == 'true' }}
   NX_PARALLEL: ${{ vars.NX_PARALLEL }}
   NX_VERBOSE_LOGGING: ${{ vars.NX_VERBOSE_LOGGING }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,13 +25,18 @@ permissions:
   contents: read
 
 # Environment details:
-# - renovate branches should never use Nx Cloud
+# - Nx Cloud (cache + distributed agents) is used for human-driven runs:
+#   PRs, pushes to main, merge_group, and manual workflow_dispatch.
+# - Disabled only for machine-driven runs — renovate branches (matched on
+#   push and PR via head_ref/ref_name) — or via the NX_NO_CLOUD repo variable,
+#   to keep costs down on high-frequency bot traffic.
 env:
   CDWR_DEBUG_LOGGING: true
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+  # Keep agents fed with tasks as soon as they come online.
+  NX_CLOUD_CONTINUOUS_ASSIGNMENT: true
   NX_NO_CLOUD: ${{ startsWith(github.head_ref || github.ref_name, 'renovate') ||
-    github.event_name == 'push' || github.event_name == 'workflow_dispatch' ||
-    vars.NX_NO_CLOUD }}
+    vars.NX_NO_CLOUD == 'true' }}
   NX_PARALLEL: ${{ vars.NX_PARALLEL }}
   NX_VERBOSE_LOGGING: ${{ vars.NX_VERBOSE_LOGGING }}
 
@@ -61,6 +66,29 @@ jobs:
       - name: Analyze affected projects
         uses: nrwl/nx-set-shas@v5
 
+      # Distribute lint/test/build across Nx Agents, only when Nx Cloud is
+      # active. Follows the NX_NO_CLOUD rule above (off for renovate branches
+      # or the kill-switch variable), the same guard the record/format steps
+      # below use.
+      # - require-explicit-completion: keep the run open across the format
+      #   check, the main task command, and `nx fix-ci` self-healing; the run
+      #   is closed by the guarded "Stop Nx Cloud CI run" step.
+      # - stop-agents-on-failure=false: a failing task must not tear the run
+      #   down before `nx fix-ci` can analyze it.
+      - name: Start Nx Cloud CI run (distributed agents)
+        if: env.NX_NO_CLOUD != 'true'
+        # Distribution is an optimization: if starting the run fails (Nx Cloud
+        # outage, agent misconfig) don't block the job — `nx affected` below
+        # degrades to local execution. The failed step stays visible as an
+        # annotation so setup problems are still noticed.
+        continue-on-error: true
+        run: |
+          pnpm nx-cloud start-ci-run \
+            --distribute-on=".nx/workflows/distribution-config.yaml" \
+            --with-env-vars="CDWR_DEBUG_LOGGING" \
+            --require-explicit-completion \
+            --stop-agents-on-failure=false
+
       - name: Cache Next.js build
         uses: actions/cache@v5
         with:
@@ -83,9 +111,23 @@ jobs:
 
       - run: pnpm nx affected -t lint,test,build -c ci
 
+      # Runs even when the affected command fails — that's the case self-healing
+      # exists to analyze, and it pairs with --stop-agents-on-failure=false so
+      # agents are still available for it.
       - name: Nx Self-healing CI
+        if: always()
         run: pnpm nx fix-ci
 
       - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+      # Close the run started above and release any still-running agents.
+      # Paired with --require-explicit-completion; always runs so agents are
+      # never orphaned, guarded to the same condition as start-ci-run.
+      - name: Stop Nx Cloud CI run
+        if: always() && env.NX_NO_CLOUD != 'true'
+        # Best-effort teardown: if the run was never started (start step above
+        # failed) or completion errors, don't fail the job over it.
+        continue-on-error: true
+        run: pnpm nx-cloud complete-ci-run

--- a/.nx/workflows/agents.yaml
+++ b/.nx/workflows/agents.yaml
@@ -1,0 +1,44 @@
+# Custom Nx Agents launch template(s) for distributed task execution.
+#
+# Referenced by .nx/workflows/distribution-config.yaml (via `--distribute-on`)
+# which is wired into the CI "checks" job in .github/workflows/ci.yml.
+#
+# The template mirrors what the coordinator job does on a GitHub `ubuntu-latest`
+# runner: check out the repo, install pnpm deps (Node 22), and install the
+# Playwright browser used by the Storybook `test` target.
+launch-templates:
+  cdwr-linux-medium-js:
+    # ubuntu-latest is 4 vCPU / 16 GB. medium+ is the closest agent class;
+    # bump to `large` here if the cms Next.js build/tests OOM on agents.
+    resource-class: "docker_linux_amd64/medium+"
+    # Standard Nx Agents base image. Node is pinned explicitly below to match
+    # the workspace requirement (.nvmrc / setup-node), independent of the image.
+    image: "ubuntu22.04-node24.14-v1"
+    init-steps:
+      - name: Checkout
+        uses: "nrwl/nx-cloud-workflows/v6/workflow-steps/checkout/main.yaml"
+
+      # Restore node_modules keyed on the pnpm lockfile + patches so most agents
+      # skip a cold install. install-node-modules below fills any cache miss.
+      - name: Restore Node Modules Cache
+        uses: "nrwl/nx-cloud-workflows/v6/workflow-steps/cache/main.yaml"
+        inputs:
+          key: "pnpm-lock.yaml|patches/**"
+          paths: "node_modules"
+          base-branch: "main"
+
+      # Pin Node 22 to match .nvmrc (22.22.2) and the coordinator's setup-node,
+      # rather than relying on the base image's bundled Node.
+      - name: Install Node
+        uses: "nrwl/nx-cloud-workflows/v6/workflow-steps/install-node/main.yaml"
+        inputs:
+          node_version: "22.22.2"
+
+      # Uses corepack + the `packageManager` field (pnpm@9.15.9) automatically.
+      - name: Install Node Modules
+        uses: "nrwl/nx-cloud-workflows/v6/workflow-steps/install-node-modules/main.yaml"
+
+      # Installs the Playwright browser the Storybook `test` target needs
+      # (coordinator installs `chromium --with-deps` for the same reason).
+      - name: Install Browsers
+        uses: "nrwl/nx-cloud-workflows/v6/workflow-steps/install-browsers/main.yaml"

--- a/.nx/workflows/distribution-config.yaml
+++ b/.nx/workflows/distribution-config.yaml
@@ -1,0 +1,16 @@
+# Dynamic agent distribution for the CI "checks" job (lint / test / build).
+#
+# Nx Cloud scales the number of agents with the size of the affected graph.
+# Entries MUST be ordered smallest -> largest changeset; Nx Cloud uses their
+# position to pick a tier. All tiers reference the custom launch template in
+# .nx/workflows/agents.yaml.
+#
+# Total distributed task concurrency = agent count (below) x per-agent task
+# concurrency. Per-agent concurrency follows Nx's parallelism setting: this
+# workflow uses the NX_PARALLEL env var (unset -> Nx default of 3), not an
+# explicit `--parallel` flag. Tune agent count here; tune per-agent
+# concurrency via NX_PARALLEL (or by adding `--parallel` to the nx command).
+distribute-on:
+  small-changeset: 3 cdwr-linux-medium-js
+  medium-changeset: 5 cdwr-linux-medium-js
+  large-changeset: 8 cdwr-linux-medium-js


### PR DESCRIPTION
Tracked in [COD-406](https://linear.app/codeware/issue/COD-406/ci-distribute-ci-checks-across-nx-agents-cost-aware-cloud).

## Summary

Move the `CI / checks` job (`nx affected -t lint,test,build -c ci`) onto **Nx Agents** distributed task execution, and align the Nx Cloud enablement rule to be **cost-aware** — human-driven runs use cloud, renovate bot traffic does not.

## Changes

- **`.nx/workflows/agents.yaml`** (new) — custom launch template `cdwr-linux-medium-js` (Node 22.22.2, pnpm, Playwright browser) on `ubuntu22.04-node24.14-v1`.
- **`.nx/workflows/distribution-config.yaml`** (new) — dynamic agent tiers (3 / 5 / 8) scaling with affected-graph size.
- **`.github/workflows/ci.yml`** — guarded `nx-cloud start-ci-run` (`--require-explicit-completion`, `--stop-agents-on-failure=false`) + guarded `complete-ci-run`; `NX_CLOUD_CONTINUOUS_ASSIGNMENT: true`.
- **`ci.yml` + `chromatic.yml`** — `NX_NO_CLOUD` now disables cloud only for renovate branches / `vars.NX_NO_CLOUD`, so pushes to `main` and `workflow_dispatch` use cloud (previously off).

### Cost rule

Cloud on for PRs, pushes to `main`, `merge_group`, manual dispatch. Off for `renovate/**` (matched via `head_ref`/`ref_name` on both push and PR) — the high-frequency bot actor — and via the `vars.NX_NO_CLOUD` kill switch.

### Intentionally unchanged

- `e2e-matrix.yml` — cross-OS/PM matrix, can't run on Linux-only agents; already renovate-guarded + opt-in via `NX_E2E_USE_CLOUD`.
- `ci-extended.yml` — `NX_NO_CLOUD: true`; deliberate opt-out (e2e/integration need Fly/Infisical secrets, not distribution candidates).

## Validation still required

- [ ] Trial PR run: agents start, receive tasks, restore cache, shut down via `complete-ci-run`.
- [ ] Confirm Nx Cloud org has Nx Agents enabled and accepts the custom launch template.
- [ ] Watch first cms `build`/`test` on `medium+` for OOM (bump to `large` if needed).
- [ ] Confirm `install-browsers` provisions the Chromium build the Storybook `test` target expects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)