### PR TITLE
Migrate Nx plugins to node16 module resolution (COD-409)

### DIFF
--- a/packages/create-nx-payload/package.json
+++ b/packages/create-nx-payload/package.json
@@ -1,6 +1,7 @@
 {
   "name": "create-nx-payload",
   "version": "2.0.3",
+  "type": "commonjs",
   "private": false,
   "description": "Quickly scaffold a new Nx workspace with a Payload CMS admin application.",
   "repository": {

--- a/packages/create-nx-payload/tsconfig.json
+++ b/packages/create-nx-payload/tsconfig.json
@@ -1,13 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "commonjs",
-    // Published as a CommonJS Nx preset. `node10` resolution is deprecated in
-    // TypeScript 6; migrating to `node16`/`nodenext` requires explicit `.js`
-    // import extensions and ESM/CJS interop changes, tracked separately. Keep
-    // `node10` until then and silence the TS 6 deprecation.
-    "moduleResolution": "node10",
-    "ignoreDeprecations": "6.0"
+    // Published as a CommonJS Nx preset (package.json `type: commonjs`), so
+    // node16 emits CJS and keeps extensionless relative imports valid.
+    "module": "node16",
+    "moduleResolution": "node16"
   },
   "files": [],
   "include": [],

--- a/packages/nx-ai/src/generators/init/init.ts
+++ b/packages/nx-ai/src/generators/init/init.ts
@@ -42,7 +42,7 @@ export async function initGeneratorInternal(
   tasks.push(installTask);
 
   if (schema.addPlugin) {
-    const { createNodesV2 } = await import('../../plugins/plugin');
+    const { createNodesV2 } = await import('../../plugins/plugin.js');
 
     await addPlugin(
       host,

--- a/packages/nx-ai/tsconfig.json
+++ b/packages/nx-ai/tsconfig.json
@@ -1,13 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "commonjs",
-    // Published as a CommonJS Nx plugin. `node10` resolution is deprecated in
-    // TypeScript 6; migrating to `node16`/`nodenext` requires explicit `.js`
-    // import extensions and ESM/CJS interop changes, tracked separately. Keep
-    // `node10` until then and silence the TS 6 deprecation.
-    "moduleResolution": "node10",
-    "ignoreDeprecations": "6.0",
+    // Published as a CommonJS Nx plugin (package.json `type: commonjs`), so
+    // node16 emits CJS and keeps extensionless relative imports valid.
+    "module": "node16",
+    "moduleResolution": "node16",
     "esModuleInterop": true
   },
   "files": [],

--- a/packages/nx-payload/src/generators/init/init.ts
+++ b/packages/nx-payload/src/generators/init/init.ts
@@ -45,7 +45,7 @@ export async function initGeneratorInternal(
   tasks.push(installTask);
 
   if (schema.addPlugin) {
-    const { createNodesV2 } = await import('../../plugins/plugin');
+    const { createNodesV2 } = await import('../../plugins/plugin.js');
 
     await addPlugin(
       host,

--- a/packages/nx-payload/src/utils/extract-payload-config.ts
+++ b/packages/nx-payload/src/utils/extract-payload-config.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { performance } from 'perf_hooks';
 
-import type { Config } from 'payload';
+import type { Config } from 'payload' with { 'resolution-mode': 'import' };
 import ts from 'typescript';
 
 import { ConfigExtractor } from './config-extractor.class';

--- a/packages/nx-payload/tsconfig.json
+++ b/packages/nx-payload/tsconfig.json
@@ -1,13 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "commonjs",
-    // Published as a CommonJS Nx plugin. `node10` resolution is deprecated in
-    // TypeScript 6; migrating to `node16`/`nodenext` requires explicit `.js`
-    // import extensions and ESM/CJS interop changes, tracked separately. Keep
-    // `node10` until then and silence the TS 6 deprecation.
-    "moduleResolution": "node10",
-    "ignoreDeprecations": "6.0",
+    // Published as a CommonJS Nx plugin (package.json `type: commonjs`), so
+    // node16 emits CJS and keeps extensionless relative imports valid.
+    "module": "node16",
+    "moduleResolution": "node16",
     "esModuleInterop": true
   },
   "files": [],


### PR DESCRIPTION
Closes COD-409. Migrates the three CJS Nx plugins off deprecated `moduleResolution: node10` — the sole source of the TS 6 friction tracked in COD-403 — to `node16`, and removes the `ignoreDeprecations: "6.0"` shims.

## Approach
The plugins stay **CommonJS** (`package.json` `type: commonjs`), so `node16` emits the same CJS output and keeps extensionless *static* relative imports valid. Only two interop points needed touching:

- **`nx-payload`** — a CJS→ESM type import of `payload` (v3, ESM-only) now needs a `resolution-mode` attribute:
  `import type { Config } from 'payload' with { 'resolution-mode': 'import' }`.
- **`nx-payload` + `nx-ai`** — a dynamic `await import('../../plugins/plugin')` needs the explicit `.js` extension under node16 (dynamic import is real ESM resolution, unlike static CJS requires).
- **`create-nx-payload`** — added explicit `type: commonjs` (it relied on the default) so node16 classifies it correctly.

## Verification
- `build + test + lint` green for all three plugins.
- **Emitted output confirms external consumers are unaffected**: `index.js`/`init.js` are still byte-compatible CJS (`require`/`exports`), the dynamic import emits `../../plugins/plugin.js`, `package.json` stays `type: commonjs`, and the `.d.ts` carries the `resolution-mode` attribute (resolvable by any TS 4.7+ consumer). No `exports` map was added, so `@cdwr/nx-payload/package.json` still resolves for nx.
- No `node10` / `ignoreDeprecations` remain in the plugins.

## Note on `nx-payload-e2e`
The plugin e2e (`--configuration=quick`) fails locally with `Cannot find module '@cdwr/nx-payload/package.json'` in the generated workspace — **but it fails identically on `main` without this change**, so it is pre-existing (packages-hygiene merge or local-registry environment), not a regression here. Leaving CI to run the authoritative e2e; flagging the baseline failure separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
