### PR TITLE
fix(repo): push app tags as the ruleset bypass app

### DIFF
--- a/.github/workflows/fly-deployment.yml
+++ b/.github/workflows/fly-deployment.yml
@@ -198,6 +198,8 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          # Push tags as the app, the ruleset's bypass actor
+          token: ${{ steps.generate-token.outputs.token }}
 
       - uses: pnpm/action-setup@v5
 


### PR DESCRIPTION
Production app tags (`cms-1.1.0`, `web-1.1.0`) were rejected on merge:

```
remote: error: GH013: Repository rule violations found for refs/tags/cms-1.1.0
- Cannot create ref due to creations being restricted.
```

The `Create release tags` ruleset now lists the `codeware-actions` app as a bypass actor, but the tag push did not authenticate as it. The `build` job's checkout took no `token:`, so pushes used the default `GITHUB_TOKEN` (`github-actions[bot]`), which is not a bypass actor. The `codeware-actions[bot]` name on existing tags is only `git config` metadata from `CDWR_COMMITTER` — not the push identity.

The job already mints an app token for the Fly actions; this points the checkout at it so `git push` inherits the app identity.

## Notes

- Only the `creation` rule fired on the last failure. `required_linear_history` passed, confirming main is linear and that tags land on real commits.
- No workflow triggers on tags, so pushing them as an app (which, unlike `GITHUB_TOKEN`, can trigger workflows) causes no re-trigger loop.
- The `refs/tags/*-preview.*` exclude is left in place. Once this lands and production tagging is confirmed, it can be removed as cleanup — a bypass actor skips the whole ruleset, so it no longer serves a purpose for CI.

## Verification

Merging this triggers a `push main` run that attempts production app tags — that is the end-to-end test of the bypass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)