### PR TITLE
fix(repo): skip app tags in publish workflow

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -14,6 +14,9 @@ on:
     tags:
       - "*-[0-9]*.[0-9]*.[0-9]*" # Matches any package name followed by semver, e.g. core-2.0.0
       - "*-[0-9]*.[0-9]*.[0-9]*-*.[0-9]*" # Also matches prerelease versions, e.g. core-2.0.0-beta.1
+      # Apps are versioned by the deployment workflow and never published
+      - "!cms-*"
+      - "!web-*"
 
   # Fall back if tag push doesn't fire, since tags and releases are created together by `nx release-cli`
   release:


### PR DESCRIPTION
Pushing `cms-1.1.0` / `web-1.1.0` triggered `publish-package.yml`, which matched them as package releases:

```
NX  Based on your config, the following projects were matched for publishing
    but do not have the "nx-release-publish" target specified:
- cms
```

Both runs failed. Nothing reached npm — the apps are `"private": true`, so Nx refused before the publish step. The failure was the safety net, not the fix.

## Cause

App tags never triggered this workflow before because they were pushed with the default `GITHUB_TOKEN`, which does not trigger workflows. Switching the tag push to the app token (so it could bypass the release-tag ruleset) also made tag pushes trigger workflows.

The publish tag filters intentionally mirror the ruleset patterns, and app tags share the same `<name>-<semver>` shape — so they matched.

## Fix

Exclude app tags at the trigger. Verified against the filter-pattern semantics:

| tag | publish fires |
| --- | --- |
| `cms-1.1.0`, `web-1.1.0` | no |
| `cms-1.2.0-preview.461.0` | no |
| `nx-payload-2.2.1`, `create-nx-payload-1.0.0` | yes |
| `fly-node-0.3.0`, `core-1.4.4` | yes |
| `nx-payload-2.0.0-beta.1` | yes |

A deny-list of the two app prefixes is lower maintenance than an allow-list of package prefixes, since packages are added more often than apps.

Note this deliberately diverges from the "should match the ruleset patterns" comment above the filters — app tags are versioned by the deployment workflow and are never published, so the two sets are no longer meant to be identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)