### PR TITLE
perf(cms): remove redundant database round-trips in the admin UI

### DIFF
--- a/apps/cms/src/app/(payload)/admin/importMap.js
+++ b/apps/cms/src/app/(payload)/admin/importMap.js
@@ -49,6 +49,7 @@ import { default as default_d2a49a891cfd08d367302de7c6a74341 } from '@codeware/a
 import { default as default_f3773f76922e241362ad8aac9e97fbcb } from '@codeware/apps/cms/components/admin/HelpDrawer.client';
 import { default as default_84801fdbb38ee83f29d6ca3070e6c648 } from '@codeware/apps/cms/components/admin/LocaleSwitch.client';
 import { default as default_221d51dba9c38b54ffc2c5a41546df9e } from '@codeware/apps/cms/components/admin/palette/PaletteTrigger.client';
+import { default as default_a700d0a80144b7c5d2f038a255456e2a } from '@codeware/apps/cms/components/admin/PerfStatsLink.client';
 import { default as default_c095f786e1e127492688aadc0a2d34be } from '@codeware/apps/cms/components/admin/AboutDialogHost.client';
 import { GlobalViewRedirect as GlobalViewRedirect_d6d5f193a167989e2ee7d14202901e62 } from '@payloadcms/plugin-multi-tenant/rsc';
 import { TenantSelector as TenantSelector_d6d5f193a167989e2ee7d14202901e62 } from '@payloadcms/plugin-multi-tenant/rsc';
@@ -162,6 +163,8 @@ export const importMap = {
     default_84801fdbb38ee83f29d6ca3070e6c648,
   '@codeware/apps/cms/components/admin/palette/PaletteTrigger.client#default':
     default_221d51dba9c38b54ffc2c5a41546df9e,
+  '@codeware/apps/cms/components/admin/PerfStatsLink.client#default':
+    default_a700d0a80144b7c5d2f038a255456e2a,
   '@codeware/apps/cms/components/admin/AboutDialogHost.client#default':
     default_c095f786e1e127492688aadc0a2d34be,
   '@payloadcms/plugin-multi-tenant/rsc#GlobalViewRedirect':

--- a/apps/cms/src/collections/site-settings/site-settings.collection.ts
+++ b/apps/cms/src/collections/site-settings/site-settings.collection.ts
@@ -13,6 +13,7 @@ import type {
 import type { CollectionConfig, Condition } from 'payload';
 
 import { userOrApiKeyAccess } from '../../security/user-or-api-key-access';
+import { invalidateIconMap } from '../tenants/hooks/populate-icon.hook';
 
 import { sanitizeSvgHook } from './hooks/sanitize-svg.hook';
 
@@ -42,7 +43,14 @@ const siteSettings: CollectionConfig = {
     update: systemUserOrTenantAdminAccess
   },
   hooks: {
-    beforeChange: [sanitizeSvgHook]
+    beforeChange: [sanitizeSvgHook],
+    // Tenant icons are derived from these settings and cached — drop it on edit
+    afterChange: [
+      ({ doc }) => {
+        invalidateIconMap();
+        return doc;
+      }
+    ]
   },
   labels: {
     singular: { en: 'Site Settings', sv: 'Webbplatsinställningar' },

--- a/apps/cms/src/collections/tenants/access/restrict-to-tenant-in-tenant-mode.ts
+++ b/apps/cms/src/collections/tenants/access/restrict-to-tenant-in-tenant-mode.ts
@@ -3,6 +3,8 @@ import { isUser } from '@codeware/app-cms/util/misc';
 import type { User } from '@codeware/shared/util/payload-types';
 import type { Access } from 'payload';
 
+import { findTenantByApiKey } from '../../../security/find-tenant-by-api-key';
+
 /**
  * Restrict access to the tenant matching the current deployment's API key in tenant mode.
  *
@@ -23,12 +25,9 @@ export const restrictToTenantInTenantMode: Access<User> = async ({
 
   if (tenantContext) {
     // Fetch tenant ID from API key
-    const { docs: allTenants } = await payload.find({
-      collection: 'tenants',
-      pagination: false
-    });
-    const tenant = allTenants.find(
-      (t) => t.apiKey === tenantContext.tenantApiKey
+    const tenant = await findTenantByApiKey(
+      payload,
+      tenantContext.tenantApiKey
     );
     // Restrict to this tenant only
     return {

--- a/apps/cms/src/collections/tenants/hooks/populate-icon.hook.ts
+++ b/apps/cms/src/collections/tenants/hooks/populate-icon.hook.ts
@@ -7,10 +7,23 @@ import type { CollectionAfterReadHook, PayloadRequest } from 'payload';
 type IconMap = Map<number, TenantIconConfig | null>;
 
 /**
+ * Tenant reads arrive as separate Payload operations (access control,
+ * filterAvailableLocales, the multi-tenant plugin), each with its own `req` and
+ * therefore its own context — so a per-request cache alone still rebuilt this
+ * map ~21 times per admin render. Icons change rarely, so the map is held
+ * process-wide for a short window and dropped whenever site-settings change.
+ */
+const CACHE_TTL_MS = 30_000;
+let cached: { at: number; promise: Promise<IconMap> } | undefined;
+
+/** Called from the site-settings afterChange hook so edits show up immediately */
+export const invalidateIconMap = (): void => {
+  cached = undefined;
+};
+
+/**
  * Fetches all site-settings in two batched queries (settings + any media URLs)
  * and returns a map of tenantId → iconConfig.
- *
- * Called once per request; the result is cached on req.context.
  */
 const buildIconMap = async (req: PayloadRequest): Promise<IconMap> => {
   const settings = await req.payload.find({
@@ -20,6 +33,10 @@ const buildIconMap = async (req: PayloadRequest): Promise<IconMap> => {
     depth: 0,
     pagination: false,
     select: { tenant: true, general: { icon: true } },
+    // Cached across requests, so the result must not depend on the caller.
+    // Safe: entries are only ever read for tenant docs that already passed
+    // access control in the hook below.
+    overrideAccess: true,
     req
   });
 
@@ -39,6 +56,7 @@ const buildIconMap = async (req: PayloadRequest): Promise<IconMap> => {
       limit: fileIds.length,
       depth: 0,
       select: { url: true },
+      overrideAccess: true,
       req
     });
     urlById = new Map(media.docs.map((m) => [m.id, m.url ?? '']));
@@ -70,20 +88,23 @@ const buildIconMap = async (req: PayloadRequest): Promise<IconMap> => {
 /**
  * Populates the virtual `iconConfig` field from the tenant's site-settings.
  *
- * All afterRead calls within a single request share one batched lookup via
- * req.context, reducing the query cost from N+1 to at most 2 queries flat.
+ * All afterRead calls share one batched lookup, reducing the query cost from
+ * N+1 to at most 2 queries per cache window.
  */
 export const populateIconHook: CollectionAfterReadHook<Tenant> = async ({
   doc,
-  req,
-  context
+  req
 }) => {
-  if (!context.tenantIconMap) {
-    context.tenantIconMap = buildIconMap(req);
+  if (!cached || Date.now() - cached.at >= CACHE_TTL_MS) {
+    const promise = buildIconMap(req).catch((error) => {
+      // Never cache a failed lookup — the next read should retry
+      cached = undefined;
+      throw error;
+    });
+    cached = { at: Date.now(), promise };
   }
 
-  const iconConfig =
-    (await (context.tenantIconMap as Promise<IconMap>)).get(doc.id) ?? null;
+  const iconConfig = (await cached.promise).get(doc.id) ?? null;
 
   return { ...doc, iconConfig };
 };

--- a/apps/cms/src/components/admin/PerfStatsLink.client.tsx
+++ b/apps/cms/src/components/admin/PerfStatsLink.client.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { Button } from '@codeware/shared/ui/shadcn/components/button';
+import { ChartBarSquareIcon } from '@heroicons/react/24/outline';
+import React from 'react';
+
+/**
+ * Toolbar shortcut to the query profiler (`admin.components.actions`).
+ *
+ * The profiler only exists in local development, so the server decides whether
+ * to render this at all and passes the result down — a client component cannot
+ * read `DEPLOY_ENV` itself.
+ */
+export function PerfStatsLink({ enabled }: { enabled: boolean }) {
+  if (!enabled) {
+    return null;
+  }
+
+  const label = 'Query profiler';
+
+  return (
+    <div className="codeware-admin twp flex items-center">
+      <Button
+        asChild
+        variant="ghost"
+        size="icon-xs"
+        title={label}
+        className="rounded-full"
+      >
+        {/* A Payload API route rendering plain HTML, not a Next page — client
+            -side routing would break it. The new tab also keeps the admin page
+            you are profiling open. */}
+        <a href="/api/perf-stats" target="_blank" rel="noreferrer">
+          <ChartBarSquareIcon className="size-3.5" />
+          <span className="sr-only">{label}</span>
+        </a>
+      </Button>
+    </div>
+  );
+}
+
+export default PerfStatsLink;

--- a/apps/cms/src/endpoints/perf-stats.ts
+++ b/apps/cms/src/endpoints/perf-stats.ts
@@ -1,0 +1,125 @@
+import { getEnv } from '@codeware/app-cms/feature/env-loader';
+import { isUser } from '@codeware/app-cms/util/misc';
+import { StatusCodes, getReasonPhrase } from 'http-status-codes';
+import { type Endpoint, type PayloadRequest, headersWithCors } from 'payload';
+
+import {
+  readQueryStats,
+  resetQueryStats,
+  setCollecting
+} from '../perf/query-stats';
+
+const escapeHtml = (value: string) =>
+  value.replace(
+    /[&<>"]/g,
+    (char) =>
+      ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' })[char] ?? char
+  );
+
+/** Scannable view for the common case: opening this straight from the URL bar */
+function renderHtml(stats: ReturnType<typeof readQueryStats>): string {
+  const rows = stats.shapes
+    .map(
+      ({ count, shape }) => `<tr>
+        <td class="n">${count}</td>
+        <td><code>${escapeHtml(shape)}</code></td>
+      </tr>`
+    )
+    .join('');
+
+  const empty = stats.collecting
+    ? '<p class="hint">No queries recorded yet — go use the admin, then Refresh.</p>'
+    : '<p class="hint">Press Start, exercise the admin UI, then come back and Refresh.</p>';
+
+  return `<!doctype html>
+<meta charset="utf-8">
+<title>Query profiler</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font: 14px/1.6 ui-monospace, monospace; margin: 2rem; max-width: 70rem; }
+  h1 { font-size: 1.1rem; margin-bottom: .25rem; }
+  .lede { font-family: system-ui, sans-serif; max-width: 46rem; }
+  .lede p { margin: .5rem 0; }
+  .bar { display: flex; gap: .5rem; margin: 1.25rem 0; flex-wrap: wrap; }
+  .bar a { padding: .3rem .7rem; border: 1px solid currentColor; border-radius: 4px; text-decoration: none; color: inherit; }
+  .bar a.back { opacity: .7; }
+  table { border-collapse: collapse; width: 100%; margin-top: 1rem; }
+  td, th { border-bottom: 1px solid rgba(128,128,128,.3); padding: .4rem .6rem; text-align: left; vertical-align: top; }
+  .n { text-align: right; font-weight: 700; white-space: nowrap; }
+  code { white-space: pre-wrap; word-break: break-all; }
+  .idle { opacity: .6; }
+  .hint, .meta { opacity: .7; }
+  .meta { font-family: system-ui, sans-serif; }
+</style>
+<h1>Query profiler — ${stats.collecting ? 'collecting' : '<span class="idle">idle</span>'}</h1>
+<div class="lede">
+  <p>Counts every database query the CMS runs and groups them by shape, ignoring
+  the arguments. A high count next to one row means that query ran many times to
+  render a single page — usually a lookup that should have been cached or batched.</p>
+  <p>That is the whole trick: Payload re-runs access control and afterRead hooks
+  per collection per operation, so one admin page can quietly fan out into
+  hundreds of identical reads. Sorting by count makes them obvious. Shapes
+  repeating more than 25 times also log a <code>[PERF]</code> warning to the dev
+  console, so you do not have to keep checking this page.</p>
+  <p class="meta">Development only, and off until you start it.</p>
+</div>
+<div class="bar">
+  <a href="?start">Start</a>
+  <a href="?stop">Stop</a>
+  <a href="?reset">Reset</a>
+  <a href="?">Refresh</a>
+  <a class="back" href="/admin">← Back to admin</a>
+</div>
+<p class="meta">${stats.total} queries · ${stats.distinctShapes} distinct shapes · ${Math.round(stats.windowMs / 1000)}s window</p>
+${stats.shapes.length ? `<table><tr><th class="n">count</th><th>query shape</th></tr>${rows}</table>` : empty}`;
+}
+
+/**
+ * Database query profiler, development only.
+ *
+ * Open it in the browser, hit Start, exercise the admin UI, then Refresh —
+ * queries are grouped by shape so repeated identical ones stand out.
+ */
+export const perfStatsEndpoint: Endpoint = {
+  path: '/perf-stats',
+  method: 'get',
+  handler: async (req: PayloadRequest): Promise<Response> => {
+    const headers = headersWithCors({ headers: new Headers(), req });
+
+    const fail = (status: number) =>
+      Response.json({ error: getReasonPhrase(status) }, { status, headers });
+
+    // Never expose profiling outside local development
+    if (getEnv().DEPLOY_ENV !== 'development') {
+      return fail(StatusCodes.NOT_FOUND);
+    }
+
+    // Admin-session users only; API key clients have no business reading this
+    if (!isUser(req.user)) {
+      return fail(StatusCodes.FORBIDDEN);
+    }
+
+    if (req.searchParams.has('start')) {
+      setCollecting(true);
+    } else if (req.searchParams.has('stop')) {
+      setCollecting(false);
+    } else if (req.searchParams.has('reset')) {
+      resetQueryStats();
+    }
+
+    const stats = readQueryStats(
+      Number(req.searchParams.get('limit')) || undefined
+    );
+
+    // Browsers navigating here get the table; curl and fetch get JSON
+    if (req.headers.get('accept')?.includes('text/html')) {
+      headers.set('content-type', 'text/html; charset=utf-8');
+      return new Response(renderHtml(stats), {
+        status: StatusCodes.OK,
+        headers
+      });
+    }
+
+    return Response.json(stats, { status: StatusCodes.OK, headers });
+  }
+};

--- a/apps/cms/src/payload.config.ts
+++ b/apps/cms/src/payload.config.ts
@@ -28,6 +28,7 @@ import { getEmailAdapter } from '@codeware/app-cms/util/email';
 import { customTranslations } from '@codeware/app-cms/util/i18n';
 import { isTenant, isUser } from '@codeware/app-cms/util/misc';
 import { getPlugins } from '@codeware/app-cms/util/plugins';
+import type { Tenant } from '@codeware/shared/util/payload-types';
 import { postgresAdapter } from '@payloadcms/db-postgres';
 import { getTenantFromCookie } from '@payloadcms/plugin-multi-tenant/utilities';
 import { en } from '@payloadcms/translations/languages/en';
@@ -194,15 +195,34 @@ export default buildConfig({
     ],
     defaultLocale: 'en',
     fallback: true,
-    // Filter available locales based on current tenant
+    // Filter available locales based on current tenant.
+    // Payload calls this several times per render, so the lookup is cached on
+    // the request context to keep it to a single query.
     filterAvailableLocales: async ({ req, locales }) => {
       const tenantId = getTenantFromCookie(req.headers, 'text');
       if (tenantId) {
-        const tenant = await req.payload.findByID({
-          id: tenantId,
-          collection: 'tenants',
-          req
-        });
+        const key = `availableLocalesTenant:${tenantId}`;
+        // `context` is typed as required but treated as optional elsewhere,
+        // and skipping the cache is harmless — only fall back to it
+        const context = req.context as Record<string, unknown> | undefined;
+        let lookup = context?.[key] as Promise<Tenant | null> | undefined;
+
+        if (!lookup) {
+          lookup = req.payload
+            .findByID({ id: tenantId, collection: 'tenants', req })
+            .catch((error) => {
+              // Never leave a rejected promise cached for the rest of the request
+              if (context) {
+                delete context[key];
+              }
+              throw error;
+            });
+          if (context) {
+            context[key] = lookup;
+          }
+        }
+
+        const tenant = await lookup;
         if (tenant && tenant.supportedLocales.length) {
           return locales.filter((locale) => {
             return tenant.supportedLocales.map(String).includes(locale.code);

--- a/apps/cms/src/payload.config.ts
+++ b/apps/cms/src/payload.config.ts
@@ -50,7 +50,9 @@ import tags from './collections/tags/tags.collection';
 import tenants from './collections/tenants/tenants.collection';
 import users from './collections/users/users.collection';
 import { paletteSearchEndpoint } from './endpoints/palette-search';
+import { perfStatsEndpoint } from './endpoints/perf-stats';
 import { tenantConfigEndpoint } from './endpoints/tenant-config';
+import { queryStatsLogger } from './perf/query-stats';
 
 const filename = fileURLToPath(import.meta.url);
 const dirname = path.dirname(filename);
@@ -69,6 +71,12 @@ export default buildConfig({
         '@codeware/apps/cms/components/admin/HelpDrawer.client',
         '@codeware/apps/cms/components/admin/LocaleSwitch.client',
         '@codeware/apps/cms/components/admin/palette/PaletteTrigger.client',
+        {
+          // Registered unconditionally to keep the import map stable; the
+          // profiler only exists in development, so gate on the rendered side.
+          path: '@codeware/apps/cms/components/admin/PerfStatsLink.client',
+          clientProps: { enabled: env.DEPLOY_ENV === 'development' }
+        },
         {
           // Client dialog host mounted (invisibly) in the actions row; opened
           // from the command palette via `OPEN_ABOUT_EVENT`. Build metadata is
@@ -162,11 +170,14 @@ export default buildConfig({
     schemaName: env.DATABASE_SCHEMA,
     migrationDir: path.resolve(dirname, 'migrations'),
     // Ensure db push is disabled during build-time
-    push: env.DISABLE_DB_PUSH === false && env.NX_RUN_TARGET !== 'build'
+    push: env.DISABLE_DB_PUSH === false && env.NX_RUN_TARGET !== 'build',
+    // Installed on dev boots only; records nothing until started from
+    // /api/perf-stats, so it costs a no-op call per query until then
+    ...(env.DEPLOY_ENV === 'development' ? { logger: queryStatsLogger } : {})
   }),
   editor: defaultLexical,
   email: getEmailAdapter(env),
-  endpoints: [paletteSearchEndpoint, tenantConfigEndpoint],
+  endpoints: [paletteSearchEndpoint, perfStatsEndpoint, tenantConfigEndpoint],
   plugins: getPlugins(env),
   secret: env.PAYLOAD_SECRET_KEY,
   upload: { safeFileNames: true },

--- a/apps/cms/src/perf/query-stats.ts
+++ b/apps/cms/src/perf/query-stats.ts
@@ -1,0 +1,104 @@
+/**
+ * Database query profiler for local development.
+ *
+ * The drizzle logger is installed on every dev boot but records nothing until
+ * collection is started from `/api/perf-stats`, so there is no env var to set
+ * and no restart needed to use it.
+ *
+ * Queries are bucketed by normalised shape — repeated identical shapes are the
+ * signal worth looking for, since Payload fans out access control and afterRead
+ * hooks per collection per operation.
+ */
+
+/** Repeats of a single shape within one window before we flag it in the log */
+const REPEAT_WARN_THRESHOLD = 25;
+
+type Stats = {
+  collecting: boolean;
+  total: number;
+  since: number;
+  shapes: Map<string, number>;
+  warned: Set<string>;
+};
+
+/**
+ * Survives dev HMR — module state would otherwise reset on every edit and
+ * discard counters mid-investigation.
+ */
+const store = globalThis as unknown as { __cmsQueryStats?: Stats };
+
+const stats = (store.__cmsQueryStats ??= {
+  collecting: false,
+  total: 0,
+  since: Date.now(),
+  shapes: new Map(),
+  warned: new Set()
+});
+
+/**
+ * Collapse bind parameters, literals and numbers so that queries differing only
+ * by argument land in the same bucket.
+ */
+function toShape(query: string): string {
+  return query
+    .replace(/\$\d+/g, '?')
+    .replace(/'[^']*'/g, "'?'")
+    .replace(/\b\d+\b/g, 'N')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function recordQuery(query: string): void {
+  if (!stats.collecting) {
+    return;
+  }
+
+  stats.total++;
+  const shape = toShape(query);
+  const count = (stats.shapes.get(shape) ?? 0) + 1;
+  stats.shapes.set(shape, count);
+
+  // Surface runaway fan-out without needing anyone to poll the endpoint
+  if (count === REPEAT_WARN_THRESHOLD && !stats.warned.has(shape)) {
+    stats.warned.add(shape);
+    console.warn(
+      `[PERF] ${count} identical queries in this window: ${shape.slice(0, 160)}`
+    );
+  }
+}
+
+export function setCollecting(collecting: boolean): void {
+  stats.collecting = collecting;
+  if (collecting) {
+    resetQueryStats();
+  }
+}
+
+export function resetQueryStats(): void {
+  stats.total = 0;
+  stats.since = Date.now();
+  stats.shapes.clear();
+  stats.warned.clear();
+}
+
+export function readQueryStats(limit = 20) {
+  const shapes = [...stats.shapes.entries()]
+    .sort(([, a], [, b]) => b - a)
+    .slice(0, limit)
+    .map(([shape, count]) => ({ count, shape }));
+
+  return {
+    collecting: stats.collecting,
+    total: stats.total,
+    distinctShapes: stats.shapes.size,
+    windowMs: Date.now() - stats.since,
+    shapes
+  };
+}
+
+/**
+ * Drizzle logger handed to the Payload postgres adapter on dev boots.
+ */
+export const queryStatsLogger = {
+  logQuery: (query: string) => recordQuery(query)
+};

--- a/apps/cms/src/security/find-tenant-by-api-key.ts
+++ b/apps/cms/src/security/find-tenant-by-api-key.ts
@@ -1,0 +1,48 @@
+import type { Tenant } from '@codeware/shared/util/payload-types';
+import type { Payload } from 'payload';
+
+/**
+ * The apiKey field is hashed in the DB index and cannot be matched via a WHERE
+ * clause, so the only way to resolve a tenant from its key is to read them all
+ * and compare in JS.
+ *
+ * Access control calls this per collection per operation, which made a single
+ * admin render resolve the same tenant hundreds of times. The identity is
+ * pinned by the deployment's API key, so it only needs re-reading often enough
+ * to pick up an edited tenant doc.
+ */
+const CACHE_TTL_MS = 10_000;
+
+const cache = new Map<
+  string,
+  { at: number; promise: Promise<Tenant | undefined> }
+>();
+
+export const findTenantByApiKey = (
+  payload: Payload,
+  apiKey: string
+): Promise<Tenant | undefined> => {
+  const cached = cache.get(apiKey);
+  if (cached && Date.now() - cached.at < CACHE_TTL_MS) {
+    return cached.promise;
+  }
+
+  const promise = payload
+    .find({
+      collection: 'tenants',
+      overrideAccess: true,
+      pagination: false,
+      // Callers only need `id` (and `apiKey` to match on), so skip relationship
+      // population on what is an access-control hot path
+      depth: 0
+    })
+    .then(({ docs }) => docs.find((t) => t.apiKey === apiKey))
+    .catch((error) => {
+      // Never cache a failed lookup — the next call should retry
+      cache.delete(apiKey);
+      throw error;
+    });
+
+  cache.set(apiKey, { at: Date.now(), promise });
+  return promise;
+};

--- a/apps/cms/src/security/resolve-scoped-tenant.ts
+++ b/apps/cms/src/security/resolve-scoped-tenant.ts
@@ -4,6 +4,18 @@ import { resolveTenantSeedFromSlug } from '@codeware/shared/util/seed';
 import { Payload } from 'payload';
 
 /**
+ * Access control calls this per collection per operation, so a single admin
+ * render resolved the same tenant hundreds of times. The identity is pinned by
+ * the deployment's API key, so it only needs re-reading often enough to pick up
+ * an edited tenant doc.
+ */
+const CACHE_TTL_MS = 10_000;
+const cache = new Map<
+  string,
+  { at: number; promise: Promise<Tenant | undefined> }
+>();
+
+/**
  * Resolves the active tenant based on the current deployment's API key in tenant mode.
  * @param payload - The Payload instance for database access
  * @returns The active Tenant or undefined if not in tenant mode or tenant not found
@@ -37,14 +49,27 @@ export const resolveScopedTenant = async (
     return undefined;
   }
 
+  const cached = cache.get(apiKey);
+  if (cached && Date.now() - cached.at < CACHE_TTL_MS) {
+    return cached.promise;
+  }
+
   // The apiKey field is hashed in the DB index and cannot be matched via
   // a WHERE clause. Fetch all tenants and match in JS — same pattern used
   // by restrictToTenantInTenantMode for the same reason.
-  const { docs } = await payload.find({
-    collection: 'tenants',
-    overrideAccess: true,
-    pagination: false
-  });
+  const promise = payload
+    .find({
+      collection: 'tenants',
+      overrideAccess: true,
+      pagination: false
+    })
+    .then(({ docs }) => docs.find((t) => t.apiKey === apiKey))
+    .catch((error) => {
+      // Never cache a failed lookup — the next call should retry
+      cache.delete(apiKey);
+      throw error;
+    });
 
-  return docs.find((t) => t.apiKey === apiKey);
+  cache.set(apiKey, { at: Date.now(), promise });
+  return promise;
 };

--- a/apps/cms/src/security/resolve-scoped-tenant.ts
+++ b/apps/cms/src/security/resolve-scoped-tenant.ts
@@ -3,17 +3,7 @@ import type { Tenant } from '@codeware/shared/util/payload-types';
 import { resolveTenantSeedFromSlug } from '@codeware/shared/util/seed';
 import { Payload } from 'payload';
 
-/**
- * Access control calls this per collection per operation, so a single admin
- * render resolved the same tenant hundreds of times. The identity is pinned by
- * the deployment's API key, so it only needs re-reading often enough to pick up
- * an edited tenant doc.
- */
-const CACHE_TTL_MS = 10_000;
-const cache = new Map<
-  string,
-  { at: number; promise: Promise<Tenant | undefined> }
->();
+import { findTenantByApiKey } from './find-tenant-by-api-key';
 
 /**
  * Resolves the active tenant based on the current deployment's API key in tenant mode.
@@ -49,27 +39,5 @@ export const resolveScopedTenant = async (
     return undefined;
   }
 
-  const cached = cache.get(apiKey);
-  if (cached && Date.now() - cached.at < CACHE_TTL_MS) {
-    return cached.promise;
-  }
-
-  // The apiKey field is hashed in the DB index and cannot be matched via
-  // a WHERE clause. Fetch all tenants and match in JS — same pattern used
-  // by restrictToTenantInTenantMode for the same reason.
-  const promise = payload
-    .find({
-      collection: 'tenants',
-      overrideAccess: true,
-      pagination: false
-    })
-    .then(({ docs }) => docs.find((t) => t.apiKey === apiKey))
-    .catch((error) => {
-      // Never cache a failed lookup — the next call should retry
-      cache.delete(apiKey);
-      throw error;
-    });
-
-  cache.set(apiKey, { at: Date.now(), promise });
-  return promise;
+  return findTenantByApiKey(payload, apiKey);
 };

--- a/libs/shared/util/zod/src/lib/with-camel-case.preprocess.spec.ts
+++ b/libs/shared/util/zod/src/lib/with-camel-case.preprocess.spec.ts
@@ -236,6 +236,23 @@ describe('withCamelCase', () => {
     });
   });
 
+  it('should handle regex metacharacters in preserve paths', () => {
+    const schema = withCamelCase(
+      z.object({ id: z.string(), 'a(b': z.record(z.string()) }),
+      { preserve: ['a(b'] }
+    );
+
+    const result = schema.parse({
+      ID: 'test',
+      'a(b': { API_KEY: 'key123' }
+    });
+
+    expect(result).toEqual({
+      id: 'test',
+      'a(b': { API_KEY: 'key123' }
+    });
+  });
+
   it('should use transformed keys in preserve option', () => {
     const schema = withCamelCase(
       z.object({

--- a/libs/shared/util/zod/src/lib/with-camel-case.preprocess.ts
+++ b/libs/shared/util/zod/src/lib/with-camel-case.preprocess.ts
@@ -85,30 +85,36 @@ const transformKeys = (options: {
 
   // Recurse transform objects
   if (data && typeof data === 'object' && data !== null) {
-    return Object.entries(data).reduce((acc, [key, value]) => {
-      // Check if current key is within the value of a key to preserve.
-      // For example `path.to.env` should preserve `env` object,
-      // and transform the `env` key to camelCase when needed.
-      const shouldPreserveValue = preserve.some((path) =>
-        [...currentPath, key].join('.').match(new RegExp(`^${path}.`))
-      );
+    // Spreading an accumulator would copy every key already collected on each
+    // iteration, making the walk quadratic; `fromEntries` stays linear.
+    return Object.fromEntries(
+      Object.entries(data).map(([key, value]) => {
+        // Check if current key is within the value of a key to preserve.
+        // For example `path.to.env` should preserve `env` object,
+        // and transform the `env` key to camelCase when needed.
+        const shouldPreserveValue = preserve.some((path) =>
+          [...currentPath, key].join('.').match(new RegExp(`^${path}.`))
+        );
 
-      const newKey = shouldPreserveValue ? key : toCamelCase(key, specialCases);
+        const newKey = shouldPreserveValue
+          ? key
+          : toCamelCase(key, specialCases);
 
-      // Store transformed paths to let `preserve` option
-      // support target schema paths.
-      const newPath = [...currentPath, newKey];
+        // Store transformed paths to let `preserve` option
+        // support target schema paths.
+        const newPath = [...currentPath, newKey];
 
-      return {
-        ...acc,
-        [newKey]: transformKeys({
-          currentPath: newPath,
-          data: value,
-          preserve,
-          specialCases
-        })
-      };
-    }, {});
+        return [
+          newKey,
+          transformKeys({
+            currentPath: newPath,
+            data: value,
+            preserve,
+            specialCases
+          })
+        ];
+      })
+    );
   }
 
   return data;

--- a/libs/shared/util/zod/src/lib/with-camel-case.preprocess.ts
+++ b/libs/shared/util/zod/src/lib/with-camel-case.preprocess.ts
@@ -92,8 +92,11 @@ const transformKeys = (options: {
         // Check if current key is within the value of a key to preserve.
         // For example `path.to.env` should preserve `env` object,
         // and transform the `env` key to camelCase when needed.
+        // `preserve` holds dot-notation paths, so match on the separator
+        // directly — building a RegExp from them would break on metacharacters.
+        const fullPath = [...currentPath, key].join('.');
         const shouldPreserveValue = preserve.some((path) =>
-          [...currentPath, key].join('.').match(new RegExp(`^${path}.`))
+          fullPath.startsWith(`${path}.`)
         );
 
         const newKey = shouldPreserveValue

--- a/libs/shared/util/zod/src/lib/with-env-vars.preprocess.ts
+++ b/libs/shared/util/zod/src/lib/with-env-vars.preprocess.ts
@@ -44,12 +44,14 @@ const processData = (data: unknown, options: Required<Options>): unknown => {
     data !== null &&
     !(data instanceof Date)
   ) {
-    return Object.entries(data).reduce((acc, [key, value]) => {
-      return {
-        ...acc,
-        [key]: processData(value, options)
-      };
-    }, {});
+    // Spreading an accumulator would copy every key already collected on each
+    // iteration, making the walk quadratic; `fromEntries` stays linear.
+    return Object.fromEntries(
+      Object.entries(data).map(([key, value]) => [
+        key,
+        processData(value, options)
+      ])
+    );
   }
 
   // Main Process of string values


### PR DESCRIPTION
Closes COD-421, and goes well past it.

COD-421 was filed against `getEnv()`'s quadratic preprocess. That fix is real, but measuring it on a running CMS showed it was **not** what made the admin UI slow: `getEnv` was 15–25 ms of a 1.3 s render. Profiling the actual requests found the real cost — **hundreds of redundant database round-trips per page render** — so this PR is now performance-focused, one fix per commit.

## Result

Measured on a running CMS in **tenant mode** (`TENANT_ID` set), authenticated admin session, 3 samples per route, before/after on identical hardware.

| route | wall before | wall after | db txns before | db txns after |
| -- | -- | -- | -- | -- |
| dashboard `?locale=sv` | 1.36 / 1.56 / 1.34 s | **0.34 / 0.34 / 0.33 s** | 340 / 226 / 299 | 123 / 0 / 46 |
| dashboard `?locale=en` | 1.60 / 1.31 / 1.31 s | **0.34 / 0.34 / 0.33 s** | 319 / 181 / 416 | 110 / 0 / 31 |
| pages list | 1.24 / 1.22 / 1.22 s | **0.36 / 0.35 / 0.34 s** | 262 / 269 / 165 | 62 / 0 / 39 |
| page edit view | 1.31 / 1.30 / 1.30 s | **0.47 / 0.41 / 0.41 s** | 252 / 190 / 174 | 81 / 0 / 82 |

**~3.5–4× faster on every admin route.** Captured SQL for one warmed dashboard render went from **285 queries to 50** — the 235 removed were two queries repeated (177× site-settings, 60× tenants); what remains is the dashboard's own spread of ~30 distinct reads, none repeating more than 3×.

## The commits

**`perf(shared): remove quadratic object walk in zod preprocessors`** — the original COD-421 fix. `{ ...acc, [key]: … }` in a reduce copied the whole accumulator per iteration, making the walk O(n²) in key count; `getEnv()` pushes all of `process.env` through it. Replaced with `Object.fromEntries`. Same pattern also fixed in `withCamelCase`. At 685 env keys: 10.7 ms → 0.19 ms per parse.

**`perf(cms): cache scoped tenant lookup in access control`** — `resolveScopedTenant` ran an unbounded `find` of all tenants, uncached, and in tenant mode `userOrApiKeyAccess` calls it on *every* access check. This was the single biggest cost.

**`perf(cms): cache tenant icon map across requests`** — `populateIconHook` batched via `req.context`, but tenant reads arrive as separate Payload operations each with their own `req`, so the batch never hit: 21 identical `site_settings` queries per render. Now held process-wide for 30 s and invalidated from a site-settings `afterChange` hook, so edits still show immediately.

**`perf(cms): share cached tenant-by-api-key lookup in access control`** — `restrictToTenantInTenantMode` duplicated the same "read every tenant, match the hashed API key in JS" pattern. Extracted into one memoized `findTenantByApiKey` used by both call sites.

**`perf(cms): cache tenant locale lookup per request`** — `filterAvailableLocales` did a tenant `findByID` on every call; Payload calls it several times per render. Cached on `req.context`.

**`feat(cms): add on-demand database query profiler`** — see below.

## Access-control review, please

Three of these cache inside the access-control path, so they deserve a careful read:

- `findTenantByApiKey` caches for 10 s, keyed by API key. The tenant identity is pinned by the deployment's env-supplied key, so it is effectively static; the window bounds staleness after a key rotation.
- The icon map now uses `overrideAccess: true` so the cached value cannot depend on the caller. This is safe because entries are only ever read for tenant docs that already passed access control — but it is the change I would most want a second opinion on.
- Failed lookups are never cached; both caches evict on rejection so the next call retries.

## On-demand profiler

No env var and no restart. On dev boots a drizzle logger is installed that records nothing until you start it, so it costs one no-op call per query until then. It is gated on `DEPLOY_ENV === 'development'`, so it does not exist at all in preview or production.

Open `/api/perf-stats` in the browser and you get a sorted table with Start / Stop / Reset / Refresh controls; curl and `fetch` still get JSON. Queries are bucketed by normalised shape, and any shape repeating more than 25 times in a window also logs a `[PERF]` warning, so runaway fan-out surfaces without anyone polling.

Sentry is the complement, not a replacement: it already ships `@opentelemetry/instrumentation-pg`, so every query is already a span in production traces. It just wasn't enabled locally, which is where this iteration happens.

## Copilot review

All findings addressed, each squashed into the commit it belongs to:

- **`req.context` may be absent** — treated as optional, and a rejected lookup is no longer left cached for the rest of the request.
- **`depth: 0` on the tenant read** — good catch on an access-control hot path; both consumers only use `id`, and the matcher only needs `apiKey`.
- **Profiler stored raw SQL** — dropped entirely; only the normalised shape is retained, so literals never reach the endpoint.
- **"one pass" comments were wrong** — `entries().map()` then `fromEntries` is not one pass. Reworded to describe avoiding the quadratic accumulator instead.
- **Regex injection from `preserve` paths** — real latent bug on a line this PR touches, so fixed in its own commit (`fix(shared): …`) with a regression test that fails without it. `preserve` holds dot-notation paths, so a prefix check is both safer and closer to the intent.

## Verification

`nx affected -t lint test` green across 29 projects. Existing preprocessor specs cover the zod change.

Two caveats worth stating:
- All numbers are **dev-mode**; production is faster in absolute terms, but the query multiplication is identical.
- Verified end-to-end on a running server: the profiler collects and reports correctly, the admin toolbar link renders, and the `filterAvailableLocales` tenant-cookie branch holds (53 queries with the cookie vs 51 without, no repetition).
- An earlier revision of this PR quoted "245 statements → 8". That was wrong: the capture only counted Postgres `statement:` log lines and missed extended-protocol queries logged as `execute <unnamed>:`, which are ~80% of the total. The numbers above count both. The conclusion is unchanged — the repeated offenders were unparameterised full-table reads, which is exactly what the narrower capture did see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
