### PR TITLE
feat(cms): accept a previous signature secret during rollover

### DIFF
--- a/apps/cms/src/endpoints/tenant-config.ts
+++ b/apps/cms/src/endpoints/tenant-config.ts
@@ -41,7 +41,7 @@ export const tenantConfigEndpoint: Endpoint = {
     // Verify the required request signature
     const { success, error } = verifySignature({
       headers: req.headers,
-      secret: APP_MODE.signatureSecret
+      secret: APP_MODE.signatureSecrets
     });
 
     if (!success) {

--- a/apps/cms/src/security/user-or-api-key-access.ts
+++ b/apps/cms/src/security/user-or-api-key-access.ts
@@ -90,7 +90,7 @@ export const userOrApiKeyAccess =
       if (isExternalRequest) {
         const { success, error } = verifySignature({
           headers,
-          secret: APP_MODE.signatureSecret
+          secret: APP_MODE.signatureSecrets
         });
 
         if (!success) {

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -12,6 +12,7 @@ This document explains the deployment architecture and configuration for the Cod
   - [Fly Configuration Files](#fly-configuration-files)
   - [Tenant Configuration (Infisical)](#tenant-configuration-infisical)
   - [Secret Loading: Deployment vs Runtime](#secret-loading-deployment-vs-runtime)
+  - [Signature Secret Rollover](#signature-secret-rollover)
   - [Sentry](#sentry)
   - [Deployment Rules (Required)](#deployment-rules-required)
   - [GitHub Secrets](#github-secrets)
@@ -296,6 +297,22 @@ Secrets can be resolved to either an environment variable or a hidden secret in 
 Secrets in Infisical are handled as **secrets by default**.
 
 To make a secret visible as **environment variable**, add metadata key `env` set to `true`.
+
+### Signature Secret Rollover
+
+`SIGNATURE_SECRET` is shared: every `web` deployment signs its requests with it and cms host
+verifies them. Replacing it in one place breaks every signed request, so cms host accepts an
+optional `SIGNATURE_SECRET_PREVIOUS` to keep both valid while clients roll over.
+
+| Step | Action                                                                        |
+| ---- | ----------------------------------------------------------------------------- |
+| 1    | Set `/apps/cms/SIGNATURE_SECRET_PREVIOUS` to the current secret, redeploy cms |
+| 2    | Set the new value on `SIGNATURE_SECRET` everywhere, redeploy cms              |
+| 3    | Redeploy every `web` tenant so they sign with the new secret                  |
+| 4    | Remove `SIGNATURE_SECRET_PREVIOUS`, redeploy cms                              |
+
+Skipping steps 1 and 4 works too, but every tenant site fails to load content between the
+cms and web deployments.
 
 ### Sentry
 

--- a/libs/app-cms/util/env-schema/src/lib/env.schema.ts
+++ b/libs/app-cms/util/env-schema/src/lib/env.schema.ts
@@ -12,7 +12,11 @@ type AppModeCommon = {
   /** Fully qualified URL to the cms app */
   serverURL: string;
 };
-type AppModeHost = AppModeCommon & { type: 'host'; signatureSecret: string };
+type AppModeHost = AppModeCommon & {
+  type: 'host';
+  /** Accepted request signature secrets, active secret first */
+  signatureSecrets: Array<string>;
+};
 type AppModeTenant = AppModeCommon & {
   type: 'tenant';
   apiKey: string;
@@ -92,6 +96,12 @@ export const EnvSchema = withEnvVars(
       // Api key request verification
       SIGNATURE_SECRET: z
         .string({ description: 'Secret key for API request signatures' })
+        .optional(),
+      SIGNATURE_SECRET_PREVIOUS: z
+        .string({
+          description:
+            'Previous signature secret, kept valid while clients roll over to a new one'
+        })
         .optional(),
 
       // Seed configuration
@@ -194,6 +204,7 @@ export const EnvSchema = withEnvVars(
     SENTRY_ORG,
     SENTRY_RELEASE,
     SIGNATURE_SECRET,
+    SIGNATURE_SECRET_PREVIOUS,
     TENANT_ID,
     ...env
   }) => ({
@@ -212,7 +223,10 @@ export const EnvSchema = withEnvVars(
       : ({
           type: 'host',
           serverURL: CUSTOM_URL || FLY_URL || PAYLOAD_URL,
-          signatureSecret: SIGNATURE_SECRET ?? '' // guarded by related refine above
+          signatureSecrets: [
+            SIGNATURE_SECRET ?? '', // guarded by related refine above
+            ...(SIGNATURE_SECRET_PREVIOUS ? [SIGNATURE_SECRET_PREVIOUS] : [])
+          ]
         } satisfies AppModeHost),
     // Expose Fly url for e.g. dynamic cors configuration
     FLY_URL,

--- a/libs/shared/util/signature/src/lib/verify-signature.spec.ts
+++ b/libs/shared/util/signature/src/lib/verify-signature.spec.ts
@@ -9,7 +9,7 @@ const signedHeaders = (secret: string) =>
   new Headers(generateSignature({ deviceId: randomUUID(), secret, userAgent }));
 
 describe('verifySignature', () => {
-  it('should accept a signature signed with the same secret', () => {
+  it('should accept a signature signed with the single secret', () => {
     const headers = signedHeaders('active-secret');
 
     expect(verifySignature({ headers, secret: 'active-secret' })).toEqual({
@@ -23,6 +23,54 @@ describe('verifySignature', () => {
     expect(verifySignature({ headers, secret: 'active-secret' })).toEqual({
       success: false,
       error: 'Invalid signature token'
+    });
+  });
+
+  describe('rollover', () => {
+    it('should accept a signature signed with the active secret', () => {
+      const headers = signedHeaders('active-secret');
+
+      expect(
+        verifySignature({
+          headers,
+          secret: ['active-secret', 'previous-secret']
+        })
+      ).toEqual({ success: true });
+    });
+
+    it('should accept a signature signed with the previous secret', () => {
+      const headers = signedHeaders('previous-secret');
+
+      expect(
+        verifySignature({
+          headers,
+          secret: ['active-secret', 'previous-secret']
+        })
+      ).toEqual({ success: true });
+    });
+
+    it('should reject a signature signed with a retired secret', () => {
+      const headers = signedHeaders('retired-secret');
+
+      expect(
+        verifySignature({
+          headers,
+          secret: ['active-secret', 'previous-secret']
+        })
+      ).toEqual({ success: false, error: 'Invalid signature token' });
+    });
+  });
+
+  it.each([
+    ['an empty secret', ''],
+    ['an empty list', []],
+    ['a list of empty secrets', ['', '']]
+  ])('should deny %s', (_, secret) => {
+    const headers = signedHeaders('active-secret');
+
+    expect(verifySignature({ headers, secret })).toEqual({
+      success: false,
+      error: 'No signature secret provided'
     });
   });
 

--- a/libs/shared/util/signature/src/lib/verify-signature.spec.ts
+++ b/libs/shared/util/signature/src/lib/verify-signature.spec.ts
@@ -1,0 +1,47 @@
+import { randomUUID } from 'crypto';
+
+import { generateSignature } from './generate-signature';
+import { verifySignature } from './verify-signature';
+
+const userAgent = 'web-client/1.0.0';
+
+const signedHeaders = (secret: string) =>
+  new Headers(generateSignature({ deviceId: randomUUID(), secret, userAgent }));
+
+describe('verifySignature', () => {
+  it('should accept a signature signed with the same secret', () => {
+    const headers = signedHeaders('active-secret');
+
+    expect(verifySignature({ headers, secret: 'active-secret' })).toEqual({
+      success: true
+    });
+  });
+
+  it('should reject a signature signed with another secret', () => {
+    const headers = signedHeaders('other-secret');
+
+    expect(verifySignature({ headers, secret: 'active-secret' })).toEqual({
+      success: false,
+      error: 'Invalid signature token'
+    });
+  });
+
+  it('should reject an expired signature without throwing', () => {
+    const headers = signedHeaders('active-secret');
+
+    const result = verifySignature({
+      headers,
+      secret: 'active-secret',
+      ttl: -1
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/^Request expired \d{4}-/);
+  });
+
+  it('should reject when signature headers are missing', () => {
+    expect(
+      verifySignature({ headers: new Headers(), secret: 'active-secret' })
+    ).toMatchObject({ success: false });
+  });
+});

--- a/libs/shared/util/signature/src/lib/verify-signature.ts
+++ b/libs/shared/util/signature/src/lib/verify-signature.ts
@@ -78,7 +78,7 @@ export const verifySignature = ({
   if (Date.now() - Number(timestamp) > ttl) {
     return {
       success: false,
-      error: `Request expired ${new Date(timestamp).toISOString()} (TTL: ${ttl}ms)`
+      error: `Request expired ${new Date(Number(timestamp)).toISOString()} (TTL: ${ttl}ms)`
     };
   }
 

--- a/libs/shared/util/signature/src/lib/verify-signature.ts
+++ b/libs/shared/util/signature/src/lib/verify-signature.ts
@@ -9,8 +9,11 @@ type Args = {
 
   /**
    * The same secret key used to sign the signature.
+   *
+   * Pass several secrets to accept more than one during a rollover.
+   * Verification succeeds when any of them matches.
    */
-  secret: string;
+  secret: string | Array<string>;
 
   /**
    * The time in milliseconds before the signature is expired.
@@ -82,16 +85,31 @@ export const verifySignature = ({
     };
   }
 
-  // Verify the signature by creating a token like in the client
-  const token = createToken({
-    requestId,
-    deviceId,
-    userAgent,
-    timestamp,
-    secret
-  });
+  const secrets = (Array.isArray(secret) ? secret : [secret]).filter(Boolean);
 
-  if (clientToken !== token) {
+  if (!secrets.length) {
+    return {
+      success: false,
+      error: 'No signature secret provided'
+    };
+  }
+
+  // Verify the signature by creating a token like in the client.
+  // Any secret may match to keep requests signed with the previous
+  // secret valid while a rollover is in progress.
+  const isValid = secrets.some(
+    (secret) =>
+      clientToken ===
+      createToken({
+        requestId,
+        deviceId,
+        userAgent,
+        timestamp,
+        secret
+      })
+  );
+
+  if (!isValid) {
     return {
       success: false,
       error: 'Invalid signature token'


### PR DESCRIPTION
Enables rotating the shared `SIGNATURE_SECRET` without a maintenance window (COD-422).

Every `web` deployment signs its requests with `SIGNATURE_SECRET` and cms host verifies them, so replacing the value in one place breaks every signed request. `verifySignature` now accepts a list of secrets and cms host reads an optional `SIGNATURE_SECRET_PREVIOUS`, keeping both valid while clients roll over. `APP_MODE.signatureSecret` becomes `signatureSecrets` (active first).

Rollover procedure is documented in `docs/DEPLOYMENT.md`. No deployment-action change needed — Infisical secrets pass through generically.

Also fixes a bug found while testing: the expiry branch formatted the header's *string* timestamp via `new Date(timestamp)`, which throws `RangeError` instead of returning a denial. An expired signature therefore surfaced as a 500 from `userOrApiKeyAccess` / `tenant-config` rather than a clean deny. Committed separately.

## Test plan

- `nx test shared-util-signature` — new spec covers single/multi secret, retired secret, empty secrets, expiry, missing headers
- `nx affected -t lint test` green; `tsc -p apps/cms` clean
- Ran cms in host mode locally: `APP_MODE.signatureSecrets` resolves as expected, and a tenant API key without a valid signature is still denied on `/api/pages`

🤖 Generated with [Claude Code](https://claude.com/claude-code)