### PR TITLE
feat(tools): secret rotation tooling for COD-422

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ nx seed cms
 
 ```sh
 pnpm cdwr
-# Options: drop-db, restart-app, app-info, patch-config, infisical-tenants, infisical-data, infisical-analysis
+# Options: drop-db, restart-app, app-info, patch-config, infisical-tenants, infisical-data, infisical-analysis, rotate-tenant-key
 ```
 
 ### Release Packages

--- a/apps/cms/src/utils/rotate-tenant-key.ts
+++ b/apps/cms/src/utils/rotate-tenant-key.ts
@@ -3,8 +3,6 @@ import { randomUUID } from 'crypto';
 import { loadEnv } from '@codeware/app-cms/feature/env-loader';
 import { getPayload } from 'payload';
 
-import config from '../payload.config';
-
 /**
  * Rotate a tenant's Payload API key using the local-api.
  *
@@ -12,20 +10,37 @@ import config from '../payload.config';
  * (`update: () => false`), which the local-api bypasses with `overrideAccess`.
  * That is why rotation runs as a script rather than from the admin panel.
  *
- * Driven by env vars so the caller controls which database is targeted:
- * - `ROTATE_TENANT_SLUG` - tenant to rotate (required)
- * - `DATABASE_URL` - target database (defaults to the resolved environment)
+ * The tenant is identified by its **current API key**, not by a slug. Infisical
+ * tenant ids and Payload tenant slugs are separate namespaces - `/tenants/demo`
+ * can hold the key of a tenant slugged `star-wars` - and the key is what a
+ * deployment itself authenticates with (see `resolveScopedTenant`).
  *
- * The new key is written to stdout as `ROTATED_API_KEY=<key>` for the caller to
- * mirror into Infisical. Nothing else prints it.
+ * Driven by env vars so the caller controls which database is targeted:
+ * - `ROTATE_CURRENT_API_KEY` - the key currently in Infisical (required)
+ * - `ROTATE_DATABASE_URL` - target database, overriding whatever Infisical
+ *   resolves (required - the caller reaches the database differently than a
+ *   deployment does, through a pooler or a Fly proxy)
+ * - `ROTATE_DRY_RUN` - resolve and report the tenant without writing anything
+ * - `ROTATE_NEW_API_KEY` - the key to set, instead of generating one. Lets a
+ *   rotation be undone by putting back the key the rest of the system still has
+ *
+ * The resolved tenant and new key are written to stdout as `RESOLVED_TENANT=`
+ * and `ROTATED_API_KEY=` for the caller. Nothing else prints the key.
  */
 async function rotate() {
-  const slug = process.env['ROTATE_TENANT_SLUG'];
+  const currentApiKey = process.env['ROTATE_CURRENT_API_KEY'];
+  const databaseUrl = process.env['ROTATE_DATABASE_URL'];
 
-  if (!slug) {
-    console.error('Error: ROTATE_TENANT_SLUG is required');
+  if (!currentApiKey || !databaseUrl) {
+    console.error(
+      'Error: ROTATE_CURRENT_API_KEY and ROTATE_DATABASE_URL are required'
+    );
     process.exit(1);
   }
+
+  // Set before loading: preview databases are created by `fly postgres attach`
+  // and never reach Infisical, so the env would not validate without this.
+  process.env['DATABASE_URL'] = databaseUrl;
 
   const env = await loadEnv();
 
@@ -34,26 +49,54 @@ async function rotate() {
     process.exit(1);
   }
 
+  // `loadEnv` injects the Infisical values over `process.env`, so anything the
+  // caller set has just been overwritten. Re-apply what this script depends on
+  // before the config reads it:
+  // - the deployment's own DATABASE_URL host is not reachable from here
+  // - a rotation must never seed or push schema to the target database
+  process.env['DATABASE_URL'] = databaseUrl;
+  process.env['SEED_SOURCE'] = 'off';
+  process.env['DISABLE_DB_PUSH'] = 'true';
+
   console.log(`[DB] Using schema '${env.DATABASE_SCHEMA}'`);
+
+  // Imported after `loadEnv` - the config reads `getEnv()` at module scope and
+  // throws when the environment has not been hydrated yet. Unlike the other
+  // scripts here this one runs outside Nx, so nothing pre-loads `.env.local`.
+  const { default: config } = await import('../payload.config');
 
   const payload = await getPayload({ config });
 
+  // The key is hashed in the DB index and cannot be matched with a where
+  // clause, so resolve it the same way access control does - read them all and
+  // compare in memory.
   const { docs } = await payload.find({
     collection: 'tenants',
-    where: { slug: { equals: slug } },
     overrideAccess: true,
-    depth: 0,
-    limit: 1
+    pagination: false,
+    depth: 0
   });
 
-  const tenant = docs[0];
+  const tenant = docs.find(({ apiKey }) => apiKey === currentApiKey);
 
   if (!tenant) {
-    console.error(`Error: No tenant found with slug '${slug}'`);
+    console.error(
+      'Error: No tenant in this database uses the API key held in Infisical.\n' +
+        'Either the two have drifted apart, or this is the wrong environment.'
+    );
     process.exit(1);
   }
 
-  const apiKey = randomUUID();
+  // Resolving is the risky part to get wrong, so it can be checked on its own
+  if (process.env['ROTATE_DRY_RUN'] === 'true') {
+    console.log(
+      `[ROTATE] Would rotate tenant '${tenant.slug}' (id: ${tenant.id})`
+    );
+    console.log(`RESOLVED_TENANT=${tenant.slug}`);
+    process.exit(0);
+  }
+
+  const apiKey = process.env['ROTATE_NEW_API_KEY'] || randomUUID();
 
   await payload.update({
     collection: 'tenants',
@@ -62,10 +105,27 @@ async function rotate() {
     overrideAccess: true
   });
 
-  console.log(`[ROTATE] Tenant '${slug}' (id: ${tenant.id}) updated`);
+  console.log(`[ROTATE] Tenant '${tenant.slug}' (id: ${tenant.id}) updated`);
+  console.log(`RESOLVED_TENANT=${tenant.slug}`);
   console.log(`ROTATED_API_KEY=${apiKey}`);
 
   process.exit(0);
 }
 
-rotate();
+// Nothing here may end quietly. The caller can only tell success from failure
+// by the markers on stdout, so a swallowed error or an event loop that simply
+// runs dry would look like "no result" with an exit code of 0.
+rotate()
+  .then(() => {
+    console.error('Error: rotation ended without reporting a result');
+    process.exit(1);
+  })
+  .catch((error) => {
+    console.error(`Error: ${error instanceof Error ? error.stack : error}`);
+    process.exit(1);
+  });
+
+process.on('beforeExit', (code) => {
+  console.error(`Error: rotation exited early (code ${code})`);
+  process.exit(code || 1);
+});

--- a/apps/cms/src/utils/rotate-tenant-key.ts
+++ b/apps/cms/src/utils/rotate-tenant-key.ts
@@ -1,0 +1,71 @@
+import { randomUUID } from 'crypto';
+
+import { loadEnv } from '@codeware/app-cms/feature/env-loader';
+import { getPayload } from 'payload';
+
+import config from '../payload.config';
+
+/**
+ * Rotate a tenant's Payload API key using the local-api.
+ *
+ * The `apiKey` field is write-protected for REST, GraphQL and the admin UI
+ * (`update: () => false`), which the local-api bypasses with `overrideAccess`.
+ * That is why rotation runs as a script rather than from the admin panel.
+ *
+ * Driven by env vars so the caller controls which database is targeted:
+ * - `ROTATE_TENANT_SLUG` - tenant to rotate (required)
+ * - `DATABASE_URL` - target database (defaults to the resolved environment)
+ *
+ * The new key is written to stdout as `ROTATED_API_KEY=<key>` for the caller to
+ * mirror into Infisical. Nothing else prints it.
+ */
+async function rotate() {
+  const slug = process.env['ROTATE_TENANT_SLUG'];
+
+  if (!slug) {
+    console.error('Error: ROTATE_TENANT_SLUG is required');
+    process.exit(1);
+  }
+
+  const env = await loadEnv();
+
+  if (!env) {
+    console.error('Environment variables could not be loaded, abort');
+    process.exit(1);
+  }
+
+  console.log(`[DB] Using schema '${env.DATABASE_SCHEMA}'`);
+
+  const payload = await getPayload({ config });
+
+  const { docs } = await payload.find({
+    collection: 'tenants',
+    where: { slug: { equals: slug } },
+    overrideAccess: true,
+    depth: 0,
+    limit: 1
+  });
+
+  const tenant = docs[0];
+
+  if (!tenant) {
+    console.error(`Error: No tenant found with slug '${slug}'`);
+    process.exit(1);
+  }
+
+  const apiKey = randomUUID();
+
+  await payload.update({
+    collection: 'tenants',
+    id: tenant.id,
+    data: { apiKey, enableAPIKey: true },
+    overrideAccess: true
+  });
+
+  console.log(`[ROTATE] Tenant '${slug}' (id: ${tenant.id}) updated`);
+  console.log(`ROTATED_API_KEY=${apiKey}`);
+
+  process.exit(0);
+}
+
+rotate();

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -316,21 +316,28 @@ pnpm cdwr   # → rotate-signature-secret
 ```
 
 The two secrets _are_ the progress marker — there is nothing else to track — so the command
-reads them, works out which step is next and applies only that one. Run it again after each
-redeploy to continue:
+reads them, works out where the rollover stands and carries it through in one run:
 
-| Step | Action                                                   | Then         |
-| ---- | -------------------------------------------------------- | ------------ |
-| 1    | Copy the active secret to `SIGNATURE_SECRET_PREVIOUS`    | Redeploy cms |
-| 2    | Generate a new `SIGNATURE_SECRET` (cms now accepts both) | Redeploy cms |
-| 3    | —                                                        | Redeploy web |
-| 4    | Remove `SIGNATURE_SECRET_PREVIOUS`                       | Redeploy cms |
+| Step | Action                                                   | Then            |
+| ---- | -------------------------------------------------------- | --------------- |
+| 1    | Copy the active secret to `SIGNATURE_SECRET_PREVIOUS`    | Restart cms     |
+| 2    | Generate a new `SIGNATURE_SECRET` (cms now accepts both) | Restart cms→web |
+| 3    | Remove `SIGNATURE_SECRET_PREVIOUS`                       | Restart cms     |
 
-Step 4 is the one to be careful with: any `web` deployment still signing with the old secret
-starts failing the moment it is removed.
+Unlike `PAYLOAD_API_KEY`, this secret is a **runtime** one: cms loads `/apps/cms` recursively
+when it boots and web loads `/apps/web`, so neither holds it as a Fly secret. Restarting is
+therefore enough — no redeploy, and nothing to write to Fly.
 
-Skipping steps 1 and 4 works too, but then every tenant site fails to load content between
-the cms and web deployments.
+Ordering is what keeps it seamless. cms learns each new value before web starts using it, and
+accepts both throughout, so no request is ever rejected mid-rollover. Step 3 is the only
+destructive one, and by then every signer is already on the new secret.
+
+If a run is interrupted the progress lives in the secrets themselves, so running the command
+again resumes from wherever it stopped. An interruption leaves cms accepting _more_ secrets
+rather than fewer, which is the safe direction.
+
+Tenant-scoped cms deployments are skipped: they run in tenant mode, where the signature secret
+is not part of `APP_MODE` and nothing verifies with it.
 
 ### Tenant API Key Rotation
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -13,6 +13,7 @@ This document explains the deployment architecture and configuration for the Cod
   - [Tenant Configuration (Infisical)](#tenant-configuration-infisical)
   - [Secret Loading: Deployment vs Runtime](#secret-loading-deployment-vs-runtime)
   - [Signature Secret Rollover](#signature-secret-rollover)
+  - [Tenant API Key Rotation](#tenant-api-key-rotation)
   - [Sentry](#sentry)
   - [Deployment Rules (Required)](#deployment-rules-required)
   - [GitHub Secrets](#github-secrets)
@@ -304,15 +305,51 @@ To make a secret visible as **environment variable**, add metadata key `env` set
 verifies them. Replacing it in one place breaks every signed request, so cms host accepts an
 optional `SIGNATURE_SECRET_PREVIOUS` to keep both valid while clients roll over.
 
-| Step | Action                                                                        |
-| ---- | ----------------------------------------------------------------------------- |
-| 1    | Set `/apps/cms/SIGNATURE_SECRET_PREVIOUS` to the current secret, redeploy cms |
-| 2    | Set the new value on `SIGNATURE_SECRET` everywhere, redeploy cms              |
-| 3    | Redeploy every `web` tenant so they sign with the new secret                  |
-| 4    | Remove `SIGNATURE_SECRET_PREVIOUS`, redeploy cms                              |
+The secret lives in `/apps/cms/signature/`, which `web` picks up through an Infisical folder
+import — that is why a single value is shared by every deployment. cms loads `/apps/cms`
+recursively, so the rollover key goes in that same folder.
 
-Skipping steps 1 and 4 works too, but every tenant site fails to load content between the
-cms and web deployments.
+Drive the rollover through the CLI rather than editing Infisical by hand:
+
+```sh
+pnpm cdwr   # → rotate-signature-secret
+```
+
+The two secrets _are_ the progress marker — there is nothing else to track — so the command
+reads them, works out which step is next and applies only that one. Run it again after each
+redeploy to continue:
+
+| Step | Action                                                   | Then         |
+| ---- | -------------------------------------------------------- | ------------ |
+| 1    | Copy the active secret to `SIGNATURE_SECRET_PREVIOUS`    | Redeploy cms |
+| 2    | Generate a new `SIGNATURE_SECRET` (cms now accepts both) | Redeploy cms |
+| 3    | —                                                        | Redeploy web |
+| 4    | Remove `SIGNATURE_SECRET_PREVIOUS`                       | Redeploy cms |
+
+Step 4 is the one to be careful with: any `web` deployment still signing with the old secret
+starts failing the moment it is removed.
+
+Skipping steps 1 and 4 works too, but then every tenant site fails to load content between
+the cms and web deployments.
+
+### Tenant API Key Rotation
+
+`PAYLOAD_API_KEY` is stored twice: on the Payload tenant document (the source of truth) and
+in Infisical under every `/tenants/<id>/apps/<app>` that deploys it. Both have to move
+together, so rotate through the CLI rather than by hand:
+
+```sh
+pnpm cdwr   # → rotate-tenant-key
+```
+
+It generates a new key, writes the tenant document via the local-api, mirrors it to each
+Infisical app folder, then prints the redeploy command. The `apiKey` field is
+`update: () => false` for REST, GraphQL and the admin UI, which is why this runs as a
+script and not from the admin panel.
+
+There is no zero-downtime path — Payload stores one key per tenant. The tenant's
+deployments keep using the retired key until the redeploy completes, so that tenant serves
+errors in between. Rotate one tenant at a time.
 
 ### Sentry
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -347,9 +347,39 @@ Infisical app folder, then prints the redeploy command. The `apiKey` field is
 `update: () => false` for REST, GraphQL and the admin UI, which is why this runs as a
 script and not from the admin panel.
 
-There is no zero-downtime path — Payload stores one key per tenant. The tenant's
-deployments keep using the retired key until the redeploy completes, so that tenant serves
-errors in between. Rotate one tenant at a time.
+> [!IMPORTANT]
+> An Infisical tenant id is **not** a Payload tenant slug. `/tenants/demo` is a deployment
+> name; the tenant it configures may be slugged something else entirely. The link between
+> them is the API key — which is exactly what a deployment authenticates with, see
+> `resolveScopedTenant`.
+>
+> So the tool resolves the tenant by the key currently in Infisical, shows you which Payload
+> tenant that turned out to be, and only rotates after you confirm that mapping. If no tenant
+> matches, the two have drifted apart or the wrong environment was selected — rotating on a
+> guess would hand a new key to the wrong tenant.
+
+Reaching the database differs per environment, which the tool handles:
+
+- **Production** runs on Supabase, so `DATABASE_URL` is an Infisical secret. It is rewritten
+  to the Session Mode pooler host, which is routable from a laptop.
+- **Preview** databases are created by `fly postgres attach` at deploy time, so the URL only
+  exists as a Fly secret on that pull request's cms app — not in Infisical, and
+  `fly secrets list` returns digests rather than values. The tool asks which cms app to use,
+  starts a machine if they are all suspended, reads the URL from inside it over SSH, then
+  opens a `fly proxy` tunnel because the host is a private `.flycast` address.
+
+> [!IMPORTANT]
+> **A redeploy does not propagate a rotated key.** The deployment only sets secrets that are
+> missing from an app and logs `Secret 'X' already exists, skipping` for the rest, so a
+> changed `PAYLOAD_API_KEY` never reaches an already-deployed app that way.
+>
+> The tool therefore writes to the Fly apps itself. It stages the secret on every app the
+> tenant deploys, and only once they are all staged does it apply them — so cms and web take
+> the new key together instead of each restarting as its own secret lands.
+
+There is no zero-downtime path — Payload stores one key per tenant. The tenant's deployments
+keep using the retired key until their machines restart, so that tenant serves errors in
+between. Rotate one tenant at a time.
 
 ### Sentry
 

--- a/libs/shared/feature/infisical/src/index.ts
+++ b/libs/shared/feature/infisical/src/index.ts
@@ -1,4 +1,5 @@
 export { type Environment, EnvironmentSchema } from './lib/infisical.schemas';
+export { deleteInfisicalSecret } from './lib/delete-infisical-secret';
 export {
   type SetSecretResult,
   setInfisicalSecret

--- a/libs/shared/feature/infisical/src/index.ts
+++ b/libs/shared/feature/infisical/src/index.ts
@@ -1,5 +1,9 @@
 export { type Environment, EnvironmentSchema } from './lib/infisical.schemas';
 export {
+  type SetSecretResult,
+  setInfisicalSecret
+} from './lib/set-infisical-secret';
+export {
   type Folder,
   type FolderSecrets,
   type Secret,

--- a/libs/shared/feature/infisical/src/lib/create-client.ts
+++ b/libs/shared/feature/infisical/src/lib/create-client.ts
@@ -1,0 +1,84 @@
+import { InfisicalSDK } from '@infisical/sdk';
+
+import { type Client, ClientSchema } from './infisical.schemas';
+
+export type Credentials = {
+  /**
+   * Infisical client ID for authentication.
+   *
+   * Takes precedence over `INFISICAL_CLIENT_ID` environment variable when provided.
+   */
+  clientId?: string;
+
+  /**
+   * Infisical client secret for authentication.
+   *
+   * Takes precedence over `INFISICAL_CLIENT_SECRET` environment variable when provided.
+   */
+  clientSecret?: string;
+
+  /**
+   * Infisical project ID.
+   *
+   * Takes precedence over `INFISICAL_PROJECT_ID` environment variable when provided.
+   */
+  projectId?: string;
+
+  /**
+   * The site to use for the Infisical client.
+   *
+   * Takes precedence over `INFISICAL_SITE` environment variable when provided.
+   *
+   * Defaults to `'us'`.
+   */
+  site?: 'eu' | 'us';
+};
+
+/**
+ * Resolve credentials and return an authenticated Infisical client.
+ *
+ * Options take precedence over the `INFISICAL_*` environment variables.
+ *
+ * @throws An error if the credentials are invalid or authentication fails
+ */
+export const createClient = async ({
+  clientId,
+  clientSecret,
+  projectId,
+  site
+}: Credentials): Promise<{ client: InfisicalSDK; projectId: string }> => {
+  const optionsWithEnv: Client = {
+    INFISICAL_CLIENT_ID: clientId || process.env['INFISICAL_CLIENT_ID'] || '',
+    INFISICAL_CLIENT_SECRET:
+      clientSecret || process.env['INFISICAL_CLIENT_SECRET'] || '',
+    INFISICAL_PROJECT_ID:
+      projectId || process.env['INFISICAL_PROJECT_ID'] || '',
+    INFISICAL_SERVICE_TOKEN: process.env['INFISICAL_SERVICE_TOKEN'],
+    INFISICAL_SITE:
+      site || (process.env['INFISICAL_SITE'] as Client['INFISICAL_SITE'])
+  };
+
+  const { success, data, error } = ClientSchema.safeParse(optionsWithEnv);
+
+  if (!success) {
+    throw new Error('Could not resolve Infisical credentials', {
+      cause: error.flatten().fieldErrors
+    });
+  }
+
+  const client = new InfisicalSDK({
+    siteUrl:
+      data.INFISICAL_SITE === 'eu' ? 'https://eu.infisical.com' : undefined
+  });
+
+  if ('INFISICAL_SERVICE_TOKEN' in data) {
+    client.auth().accessToken(data.INFISICAL_SERVICE_TOKEN);
+  } else {
+    await client.auth().universalAuth.login({
+      clientId: data.INFISICAL_CLIENT_ID,
+      clientSecret: data.INFISICAL_CLIENT_SECRET
+    });
+  }
+
+  return { client, projectId: data.INFISICAL_PROJECT_ID };
+};

--- a/libs/shared/feature/infisical/src/lib/delete-infisical-secret.ts
+++ b/libs/shared/feature/infisical/src/lib/delete-infisical-secret.ts
@@ -1,0 +1,62 @@
+import { type Credentials, createClient } from './create-client';
+import { isNotFound } from './error-status';
+import { type Environment } from './infisical.schemas';
+
+type Options<TEnv> = Credentials & {
+  /**
+   * The environment to delete the secret from.
+   *
+   * Defaults to `'development'`.
+   */
+  environment?: TEnv;
+
+  /**
+   * Folder-based path to the secret.
+   *
+   * Defaults to the root folder.
+   */
+  path?: string;
+
+  /**
+   * Name of the secret to delete.
+   */
+  key: string;
+};
+
+/**
+ * Delete a single secret from Infisical.
+ *
+ * Used to retire a secret once a rollover has completed. Deleting one that does
+ * not exist is not an error - the desired end state is the same either way.
+ *
+ * Everything else does throw. A rollover retires the previous secret in its
+ * last step, so a delete that quietly failed would report the rollover
+ * complete while every verifier carried on accepting the retired secret.
+ *
+ * @returns `true` when a secret was deleted, `false` when there was none
+ * @throws An error if the credentials are invalid or the delete fails
+ */
+export const deleteInfisicalSecret = async <TEnv = Environment>({
+  environment,
+  path = '/',
+  key,
+  ...credentials
+}: Options<TEnv>): Promise<boolean> => {
+  const { client, projectId } = await createClient(credentials);
+
+  try {
+    await client.secrets().deleteSecret(key, {
+      environment:
+        environment?.toString() ?? ('development' satisfies Environment),
+      projectId,
+      secretPath: path
+    });
+    return true;
+  } catch (error) {
+    if (isNotFound(error)) {
+      return false;
+    }
+
+    throw error;
+  }
+};

--- a/libs/shared/feature/infisical/src/lib/error-status.ts
+++ b/libs/shared/feature/infisical/src/lib/error-status.ts
@@ -1,0 +1,26 @@
+/**
+ * HTTP status behind a rejected SDK call, however it chose to report it.
+ *
+ * `InfisicalSDKRequestError` carries no status field - the code only exists
+ * inside the message, as `[StatusCode=404]`.
+ */
+export const statusOf = (error: unknown): number | undefined => {
+  if (typeof error !== 'object' || error === null) {
+    return undefined;
+  }
+
+  const fromResponse = (error as { response?: { status?: number } }).response
+    ?.status;
+
+  if (fromResponse) {
+    return fromResponse;
+  }
+
+  const message = String((error as { message?: unknown }).message ?? '');
+  const matched = /\[StatusCode=(\d{3})\]/.exec(message);
+
+  return matched ? Number(matched[1]) : undefined;
+};
+
+/** Whether a rejected SDK call means the secret simply is not there */
+export const isNotFound = (error: unknown): boolean => statusOf(error) === 404;

--- a/libs/shared/feature/infisical/src/lib/set-infisical-secret.ts
+++ b/libs/shared/feature/infisical/src/lib/set-infisical-secret.ts
@@ -1,4 +1,5 @@
 import { type Credentials, createClient } from './create-client';
+import { isNotFound } from './error-status';
 import { type Environment } from './infisical.schemas';
 
 type Options<TEnv> = Credentials & {
@@ -26,31 +27,6 @@ type Options<TEnv> = Credentials & {
    */
   value: string;
 };
-
-/**
- * HTTP status behind a rejected SDK call, however it chose to report it.
- */
-const statusOf = (error: unknown): number | undefined => {
-  if (typeof error !== 'object' || error === null) {
-    return undefined;
-  }
-
-  const fromResponse = (error as { response?: { status?: number } }).response
-    ?.status;
-
-  if (fromResponse) {
-    return fromResponse;
-  }
-
-  // `InfisicalSDKRequestError` carries no status field - the code only exists
-  // inside the message, as `[StatusCode=404]`
-  const message = String((error as { message?: unknown }).message ?? '');
-  const matched = /\[StatusCode=(\d{3})\]/.exec(message);
-
-  return matched ? Number(matched[1]) : undefined;
-};
-
-const isNotFound = (error: unknown): boolean => statusOf(error) === 404;
 
 export type SetSecretResult = {
   /** Whether the secret was created or an existing one was updated */

--- a/libs/shared/feature/infisical/src/lib/set-infisical-secret.ts
+++ b/libs/shared/feature/infisical/src/lib/set-infisical-secret.ts
@@ -1,12 +1,7 @@
-import { InfisicalSDK } from '@infisical/sdk';
+import { type Credentials, createClient } from './create-client';
+import { type Environment } from './infisical.schemas';
 
-import {
-  type Client,
-  ClientSchema,
-  type Environment
-} from './infisical.schemas';
-
-type Options<TEnv> = {
+type Options<TEnv> = Credentials & {
   /**
    * The environment to write the secret to.
    *
@@ -30,37 +25,32 @@ type Options<TEnv> = {
    * Value to write.
    */
   value: string;
-
-  /**
-   * Infisical client ID for authentication.
-   *
-   * Takes precedence over `INFISICAL_CLIENT_ID` environment variable when provided.
-   */
-  clientId?: string;
-
-  /**
-   * Infisical client secret for authentication.
-   *
-   * Takes precedence over `INFISICAL_CLIENT_SECRET` environment variable when provided.
-   */
-  clientSecret?: string;
-
-  /**
-   * Infisical project ID.
-   *
-   * Takes precedence over `INFISICAL_PROJECT_ID` environment variable when provided.
-   */
-  projectId?: string;
-
-  /**
-   * The site to use for the Infisical client.
-   *
-   * Takes precedence over `INFISICAL_SITE` environment variable when provided.
-   *
-   * Defaults to `'us'`.
-   */
-  site?: 'eu' | 'us';
 };
+
+/**
+ * HTTP status behind a rejected SDK call, however it chose to report it.
+ */
+const statusOf = (error: unknown): number | undefined => {
+  if (typeof error !== 'object' || error === null) {
+    return undefined;
+  }
+
+  const fromResponse = (error as { response?: { status?: number } }).response
+    ?.status;
+
+  if (fromResponse) {
+    return fromResponse;
+  }
+
+  // `InfisicalSDKRequestError` carries no status field - the code only exists
+  // inside the message, as `[StatusCode=404]`
+  const message = String((error as { message?: unknown }).message ?? '');
+  const matched = /\[StatusCode=(\d{3})\]/.exec(message);
+
+  return matched ? Number(matched[1]) : undefined;
+};
+
+const isNotFound = (error: unknown): boolean => statusOf(error) === 404;
 
 export type SetSecretResult = {
   /** Whether the secret was created or an existing one was updated */
@@ -85,62 +75,62 @@ export const setInfisicalSecret = async <TEnv = Environment>({
   path = '/',
   key,
   value,
-  clientId,
-  clientSecret,
-  projectId,
-  site
+  ...credentials
 }: Options<TEnv>): Promise<SetSecretResult> => {
-  const optionsWithEnv: Client = {
-    INFISICAL_CLIENT_ID: clientId || process.env['INFISICAL_CLIENT_ID'] || '',
-    INFISICAL_CLIENT_SECRET:
-      clientSecret || process.env['INFISICAL_CLIENT_SECRET'] || '',
-    INFISICAL_PROJECT_ID:
-      projectId || process.env['INFISICAL_PROJECT_ID'] || '',
-    INFISICAL_SERVICE_TOKEN: process.env['INFISICAL_SERVICE_TOKEN'],
-    INFISICAL_SITE:
-      site || (process.env['INFISICAL_SITE'] as Client['INFISICAL_SITE'])
-  };
-
-  const { success, data, error } = ClientSchema.safeParse(optionsWithEnv);
-
-  if (!success) {
-    throw new Error('Could not resolve Infisical credentials', {
-      cause: error.flatten().fieldErrors
-    });
-  }
-
-  const client = new InfisicalSDK({
-    siteUrl:
-      data.INFISICAL_SITE === 'eu' ? 'https://eu.infisical.com' : undefined
-  });
-
-  if ('INFISICAL_SERVICE_TOKEN' in data) {
-    client.auth().accessToken(data.INFISICAL_SERVICE_TOKEN);
-  } else {
-    await client.auth().universalAuth.login({
-      clientId: data.INFISICAL_CLIENT_ID,
-      clientSecret: data.INFISICAL_CLIENT_SECRET
-    });
-  }
+  const { client, projectId } = await createClient(credentials);
 
   const secretOptions = {
     environment:
       environment?.toString() ?? ('development' satisfies Environment),
-    projectId: data.INFISICAL_PROJECT_ID,
+    projectId,
     secretPath: path
   };
 
+  /**
+   * Whether the stored value already matches what we tried to write.
+   *
+   * Read the way consumers do, through `listSecretsWithImports` - a plain
+   * `getSecret` returns an unusable value for tokens without permission to
+   * view plaintext, which would make every check look like a mismatch.
+   */
+  const isWritten = async () => {
+    try {
+      const secrets = await client.secrets().listSecretsWithImports({
+        ...secretOptions,
+        expandSecretReferences: true
+      });
+
+      return secrets.some(
+        ({ secretKey, secretValue }) =>
+          secretKey === key && secretValue === value
+      );
+    } catch {
+      return false;
+    }
+  };
+
   // Update first - the secret is expected to exist for a rotation.
-  // Infisical has no upsert, so fall back to create when it is missing.
+  // Infisical has no upsert, so fall back to create only when it is missing.
   try {
     await client
       .secrets()
       .updateSecret(key, { ...secretOptions, secretValue: value });
     return { action: 'updated', key, path };
-  } catch {
-    await client
-      .secrets()
-      .createSecret(key, { ...secretOptions, secretValue: value });
-    return { action: 'created', key, path };
+  } catch (error) {
+    // A write can apply and still reject: Infisical answers the update with the
+    // stored secret, so a token allowed to edit but not to read plaintext gets
+    // a 403 for a change that landed. Trust the stored value over the response.
+    if (await isWritten()) {
+      return { action: 'updated', key, path };
+    }
+
+    if (!isNotFound(error)) {
+      throw error;
+    }
   }
+
+  await client
+    .secrets()
+    .createSecret(key, { ...secretOptions, secretValue: value });
+  return { action: 'created', key, path };
 };

--- a/libs/shared/feature/infisical/src/lib/set-infisical-secret.ts
+++ b/libs/shared/feature/infisical/src/lib/set-infisical-secret.ts
@@ -1,0 +1,146 @@
+import { InfisicalSDK } from '@infisical/sdk';
+
+import {
+  type Client,
+  ClientSchema,
+  type Environment
+} from './infisical.schemas';
+
+type Options<TEnv> = {
+  /**
+   * The environment to write the secret to.
+   *
+   * Defaults to `'development'`.
+   */
+  environment?: TEnv;
+
+  /**
+   * Folder-based path to the secret.
+   *
+   * Defaults to the root folder.
+   */
+  path?: string;
+
+  /**
+   * Name of the secret to write.
+   */
+  key: string;
+
+  /**
+   * Value to write.
+   */
+  value: string;
+
+  /**
+   * Infisical client ID for authentication.
+   *
+   * Takes precedence over `INFISICAL_CLIENT_ID` environment variable when provided.
+   */
+  clientId?: string;
+
+  /**
+   * Infisical client secret for authentication.
+   *
+   * Takes precedence over `INFISICAL_CLIENT_SECRET` environment variable when provided.
+   */
+  clientSecret?: string;
+
+  /**
+   * Infisical project ID.
+   *
+   * Takes precedence over `INFISICAL_PROJECT_ID` environment variable when provided.
+   */
+  projectId?: string;
+
+  /**
+   * The site to use for the Infisical client.
+   *
+   * Takes precedence over `INFISICAL_SITE` environment variable when provided.
+   *
+   * Defaults to `'us'`.
+   */
+  site?: 'eu' | 'us';
+};
+
+export type SetSecretResult = {
+  /** Whether the secret was created or an existing one was updated */
+  action: 'created' | 'updated';
+  key: string;
+  path: string;
+};
+
+/**
+ * Write a single secret to Infisical, creating it when it does not exist.
+ *
+ * Counterpart to `withInfisical`, which only reads. Credentials resolve the same
+ * way, from options first and `INFISICAL_*` environment variables as fallback.
+ *
+ * The value is never logged - callers decide what to print.
+ *
+ * @returns Details of what was written
+ * @throws An error if the credentials are invalid or the write fails
+ */
+export const setInfisicalSecret = async <TEnv = Environment>({
+  environment,
+  path = '/',
+  key,
+  value,
+  clientId,
+  clientSecret,
+  projectId,
+  site
+}: Options<TEnv>): Promise<SetSecretResult> => {
+  const optionsWithEnv: Client = {
+    INFISICAL_CLIENT_ID: clientId || process.env['INFISICAL_CLIENT_ID'] || '',
+    INFISICAL_CLIENT_SECRET:
+      clientSecret || process.env['INFISICAL_CLIENT_SECRET'] || '',
+    INFISICAL_PROJECT_ID:
+      projectId || process.env['INFISICAL_PROJECT_ID'] || '',
+    INFISICAL_SERVICE_TOKEN: process.env['INFISICAL_SERVICE_TOKEN'],
+    INFISICAL_SITE:
+      site || (process.env['INFISICAL_SITE'] as Client['INFISICAL_SITE'])
+  };
+
+  const { success, data, error } = ClientSchema.safeParse(optionsWithEnv);
+
+  if (!success) {
+    throw new Error('Could not resolve Infisical credentials', {
+      cause: error.flatten().fieldErrors
+    });
+  }
+
+  const client = new InfisicalSDK({
+    siteUrl:
+      data.INFISICAL_SITE === 'eu' ? 'https://eu.infisical.com' : undefined
+  });
+
+  if ('INFISICAL_SERVICE_TOKEN' in data) {
+    client.auth().accessToken(data.INFISICAL_SERVICE_TOKEN);
+  } else {
+    await client.auth().universalAuth.login({
+      clientId: data.INFISICAL_CLIENT_ID,
+      clientSecret: data.INFISICAL_CLIENT_SECRET
+    });
+  }
+
+  const secretOptions = {
+    environment:
+      environment?.toString() ?? ('development' satisfies Environment),
+    projectId: data.INFISICAL_PROJECT_ID,
+    secretPath: path
+  };
+
+  // Update first - the secret is expected to exist for a rotation.
+  // Infisical has no upsert, so fall back to create when it is missing.
+  try {
+    await client
+      .secrets()
+      .updateSecret(key, { ...secretOptions, secretValue: value });
+    return { action: 'updated', key, path };
+  } catch {
+    await client
+      .secrets()
+      .createSecret(key, { ...secretOptions, secretValue: value });
+    return { action: 'created', key, path };
+  }
+};

--- a/libs/shared/util/pure/src/index.ts
+++ b/libs/shared/util/pure/src/index.ts
@@ -7,3 +7,4 @@ export * from './lib/get-sentry-sample-rate';
 export * from './lib/is-object';
 export * from './lib/is-regex-pattern';
 export * from './lib/sanitize-svg';
+export * from './lib/to-pooler-url';

--- a/libs/shared/util/pure/src/lib/to-pooler-url.spec.ts
+++ b/libs/shared/util/pure/src/lib/to-pooler-url.spec.ts
@@ -1,0 +1,36 @@
+import { toPoolerUrl } from './to-pooler-url';
+
+const region = 'eu-central-1';
+
+describe('toPoolerUrl', () => {
+  it('should convert a direct connection URL to a session mode pooler URL', () => {
+    expect(
+      toPoolerUrl(
+        'postgresql://postgres:pass@db.abc123.supabase.co:5432/postgres',
+        region
+      )
+    ).toBe(
+      'postgresql://postgres.abc123:pass@aws-0-eu-central-1.pooler.supabase.com:5432/postgres'
+    );
+  });
+
+  it('should leave a pooler URL unchanged', () => {
+    const url =
+      'postgresql://postgres.abc123:pass@aws-0-eu-central-1.pooler.supabase.com:5432/postgres';
+
+    expect(toPoolerUrl(url, region)).toBe(url);
+  });
+
+  it('should leave a non-Supabase URL unchanged', () => {
+    const url = 'postgresql://postgres:postgres@localhost:5432/cms';
+
+    expect(toPoolerUrl(url, region)).toBe(url);
+  });
+
+  it.each(['', 'not-a-url', 'db.abc123.supabase.co:5432'])(
+    'should return %p unchanged rather than throwing',
+    (value) => {
+      expect(toPoolerUrl(value, region)).toBe(value);
+    }
+  );
+});

--- a/libs/shared/util/pure/src/lib/to-pooler-url.ts
+++ b/libs/shared/util/pure/src/lib/to-pooler-url.ts
@@ -1,0 +1,33 @@
+/**
+ * Convert a Supabase direct connection URL to a Session Mode pooler URL.
+ *
+ * Direct:  postgresql://postgres:[pass]@db.[ref].supabase.co:5432/postgres
+ * Pooler:  postgresql://postgres.[ref]:[pass]@aws-0-[region].pooler.supabase.com:5432/postgres
+ *
+ * The pooler is reachable from more networks and is compatible with pg_dump
+ * (unlike Transaction Mode which does not support prepared statements).
+ *
+ * A URL that is already a pooler URL, or an unrecognised format, is returned
+ * unchanged.
+ */
+export function toPoolerUrl(dbUrl: string, region: string): string {
+  let url: URL;
+
+  try {
+    url = new URL(dbUrl);
+  } catch {
+    // Not parsable as a URL, so there is nothing to rewrite
+    return dbUrl;
+  }
+
+  const directHostMatch = url.hostname.match(/^db\.([a-z0-9]+)\.supabase\.co$/);
+
+  if (!directHostMatch) {
+    return dbUrl;
+  }
+
+  const projectRef = directHostMatch[1];
+  url.hostname = `aws-0-${region}.pooler.supabase.com`;
+  url.username = `postgres.${projectRef}`;
+  return url.toString();
+}

--- a/packages/fly-node/src/lib/fly.class.ts
+++ b/packages/fly-node/src/lib/fly.class.ts
@@ -494,6 +494,34 @@ export class Fly {
     }
   };
   /**
+   * Run commands inside a running machine
+   */
+  ssh = {
+    /**
+     * Execute a command in a running machine and return its output.
+     *
+     * Requires a started machine - Fly cannot connect to a stopped or
+     * suspended one. Use `machines.start` first when the app may be idle.
+     *
+     * The output is returned to the caller and not logged unless CLI tracing
+     * is enabled, so it can be used to read values that are otherwise
+     * write-only, such as secrets injected at deploy time.
+     *
+     * @param app - The name of the application
+     * @param command - The command to run inside the machine
+     * @returns The command output
+     * @throws An error if there is no started machine or the command fails
+     */
+    exec: async (app: string, command: string): Promise<string> => {
+      try {
+        await this.ensureInitialized();
+        return await this.sshExec(app, command);
+      } catch (error) {
+        throw new Error(`[ssh exec] something broke\n${error}`);
+      }
+    }
+  };
+  /**
    * Manage application secrets
    */
   secrets = {
@@ -519,6 +547,27 @@ export class Fly {
         throw new Error(
           `[set secrets] something broke, check your app secrets\n${error}`
         );
+      }
+    },
+    /**
+     * Apply secrets that were staged with `set({ stage: true })`.
+     *
+     * Staging first and deploying afterwards lets a set of apps take a new
+     * value together, instead of each restarting as its own secret is written.
+     *
+     * Fly needs a started machine to update, so an app whose machines are all
+     * stopped or suspended has to be started before this will do anything.
+     *
+     * @param app - The name of the application
+     * @throws An error if the staged secrets cannot be deployed
+     */
+    deploy: async (app: string): Promise<void> => {
+      try {
+        await this.ensureInitialized();
+        await this.deployStagedSecrets(app);
+        this.logger.info(`Staged secrets were deployed for '${app}'`);
+      } catch (error) {
+        throw new Error(`[deploy secrets] something broke\n${error}`);
       }
     },
     /**
@@ -1027,6 +1076,27 @@ export class Fly {
     await this.execFly(args);
 
     return NameSchema.parse(status.name);
+  }
+
+  /**
+   * @private
+   * Deploy secrets previously staged for an application
+   * @throws An error if the staged secrets cannot be deployed
+   */
+  private async deployStagedSecrets(app: string): Promise<void> {
+    const args = ['secrets', 'deploy', '--app', app];
+    await this.execFly(args);
+  }
+
+  /**
+   * @private
+   * Execute a command inside a running machine
+   * @returns The command output
+   * @throws An error if the command fails
+   */
+  private async sshExec(app: string, command: string): Promise<string> {
+    const args = ['ssh', 'console', '--app', app, '--command', command];
+    return await this.execFly<string>(args);
   }
 
   /**

--- a/tools/cdwr-cli.ts
+++ b/tools/cdwr-cli.ts
@@ -13,6 +13,7 @@ import { restartApp } from './fly-tools/lib/restart-app.js';
 import { analysisMain } from './infisical/lib/analysis.js';
 import { fetchAppTenantsMain } from './infisical/lib/fetch-app-tenants.js';
 import { fetchDataMain } from './infisical/lib/fetch-data.js';
+import { rotateTenantKeyMain } from './infisical/lib/rotate-tenant-key.js';
 
 interface Tool {
   name: string;
@@ -75,6 +76,11 @@ const tools: Tool[] = [
     name: 'infisical-analysis',
     description: 'Analyze Infisical configuration and secrets',
     action: analysisMain
+  },
+  {
+    name: 'rotate-tenant-key',
+    description: "Rotate a tenant's Payload API key in Payload and Infisical",
+    action: rotateTenantKeyMain
   }
 ];
 

--- a/tools/cdwr-cli.ts
+++ b/tools/cdwr-cli.ts
@@ -13,6 +13,7 @@ import { restartApp } from './fly-tools/lib/restart-app.js';
 import { analysisMain } from './infisical/lib/analysis.js';
 import { fetchAppTenantsMain } from './infisical/lib/fetch-app-tenants.js';
 import { fetchDataMain } from './infisical/lib/fetch-data.js';
+import { rotateSignatureSecretMain } from './infisical/lib/rotate-signature-secret.js';
 import { rotateTenantKeyMain } from './infisical/lib/rotate-tenant-key.js';
 
 interface Tool {
@@ -81,6 +82,11 @@ const tools: Tool[] = [
     name: 'rotate-tenant-key',
     description: "Rotate a tenant's Payload API key in Payload and Infisical",
     action: rotateTenantKeyMain
+  },
+  {
+    name: 'rotate-signature-secret',
+    description: 'Roll over the shared request signature secret, step by step',
+    action: rotateSignatureSecretMain
   }
 ];
 

--- a/tools/db-tools/lib/backup-db.ts
+++ b/tools/db-tools/lib/backup-db.ts
@@ -17,6 +17,7 @@ import {
   EnvironmentSchema,
   withInfisical
 } from '@codeware/shared/feature/infisical';
+import { toPoolerUrl } from '@codeware/shared/util/pure';
 import * as dotenv from 'dotenv';
 
 const execAsync = promisify(exec);
@@ -55,32 +56,6 @@ async function fetchDatabaseUrl(environment: BackupEnv): Promise<string> {
   }
 
   return dbUrlSecret.secretValue;
-}
-
-/**
- * Convert a Supabase direct connection URL to a Session Mode pooler URL.
- *
- * Direct:  postgresql://postgres:[pass]@db.[ref].supabase.co:5432/postgres
- * Pooler:  postgresql://postgres.[ref]:[pass]@aws-0-[region].pooler.supabase.com:5432/postgres
- *
- * The pooler is reachable from more networks and is compatible with pg_dump
- * (unlike Transaction Mode which does not support prepared statements).
- *
- * If the URL is already a pooler URL, it is returned unchanged.
- */
-function toPoolerUrl(dbUrl: string, region: string): string {
-  const url = new URL(dbUrl);
-  const directHostMatch = url.hostname.match(/^db\.([a-z0-9]+)\.supabase\.co$/);
-
-  if (!directHostMatch) {
-    // Already a pooler URL or an unrecognised format — use as-is
-    return dbUrl;
-  }
-
-  const projectRef = directHostMatch[1];
-  url.hostname = `aws-0-${region}.pooler.supabase.com`;
-  url.username = `postgres.${projectRef}`;
-  return url.toString();
 }
 
 /**

--- a/tools/infisical/lib/fly-apps.ts
+++ b/tools/infisical/lib/fly-apps.ts
@@ -1,0 +1,142 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import { Fly } from '@cdwr/fly-node';
+import { getAppName } from '@codeware/shared/util/nx-deploy';
+import * as TOML from 'smol-toml';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export const workspaceRoot = path.resolve(__dirname, '../../..');
+
+/**
+ * Silent client - these commands handle output themselves, and some of what
+ * the Fly CLI prints (ssh output, secret values) should not reach the console.
+ */
+export const fly = new Fly({
+  logger: {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    info: () => {},
+    error: console.error,
+    traceCLI: false,
+    redactSecrets: true,
+    verbose: false,
+    debug: false,
+    streamToConsole: false
+  }
+});
+
+/** Base Fly app name from an app's own fly config */
+export function configAppName(app: string): string {
+  const configPath = path.join(workspaceRoot, 'apps', app, 'fly.toml');
+  const config = TOML.parse(readFileSync(configPath, 'utf-8')) as {
+    app?: string;
+  };
+
+  if (!config.app) {
+    throw new Error(`No app name found in ${configPath}`);
+  }
+
+  return config.app;
+}
+
+/**
+ * Resolve the Fly app name for a tenant's deployment of an app, applying the
+ * same pull request and tenant suffixes the deployment action uses.
+ */
+export function flyAppName(
+  app: string,
+  tenantId: string,
+  pullRequest?: string
+): string {
+  return getAppName({
+    configAppName: configAppName(app),
+    environment: pullRequest ? 'preview' : 'production',
+    pullRequest: pullRequest ? Number(pullRequest) : undefined,
+    tenantId
+  });
+}
+
+/**
+ * Start every machine of an app that is not already running.
+ *
+ * Preview machines suspend when idle, and Fly can neither ssh into nor update
+ * a machine that is not started.
+ */
+export async function startMachines(app: string): Promise<void> {
+  const status = await fly.status({ app });
+  const machines = status?.machines ?? [];
+
+  if (!machines.length) {
+    throw new Error(`App '${app}' has no machines - is it deployed?`);
+  }
+
+  const stopped = machines.filter(({ state }) => state !== 'started');
+
+  for (const machine of stopped) {
+    await fly.machines.start(app, machine.id);
+  }
+
+  if (stopped.length) {
+    // Give them a moment to accept connections
+    await new Promise((resolve) => setTimeout(resolve, 5_000));
+  }
+}
+
+/** Wait until a machine reaches one of the given states */
+async function waitForMachineState(
+  app: string,
+  machineId: string,
+  states: Array<string>,
+  timeoutMs = 120_000
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const machine = (await fly.status({ app }))?.machines?.find(
+      ({ id }) => id === machineId
+    );
+
+    if (machine && states.includes(machine.state)) {
+      return;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 2_000));
+  }
+
+  throw new Error(
+    `Machine ${machineId} in '${app}' did not reach ${states.join('/')} in time`
+  );
+}
+
+/**
+ * Restart every machine of an app so it re-reads its runtime configuration.
+ *
+ * Secrets under `/apps/<app>` are fetched from Infisical when the app boots,
+ * not injected at deploy, so a restart is all it takes to pick up a new value.
+ * Stopping and starting is a cold boot - a suspended machine resumed from its
+ * snapshot would never re-read anything.
+ *
+ * Done one machine at a time, waiting for each to come back before touching
+ * the next, so the app keeps serving throughout. The waits are on observed
+ * state rather than a fixed delay: `fly-node`'s own `machines.restart` sleeps
+ * two seconds between stop and start, which is not enough - the start is
+ * rejected with `unable to start machine from current state: 'stopping'`.
+ */
+export async function restartApp(app: string): Promise<void> {
+  const status = await fly.status({ app });
+  const machines = status?.machines ?? [];
+
+  if (!machines.length) {
+    throw new Error(`App '${app}' has no machines - is it deployed?`);
+  }
+
+  for (const machine of machines) {
+    await fly.machines.stop(app, machine.id);
+    await waitForMachineState(app, machine.id, ['stopped', 'suspended']);
+
+    await fly.machines.start(app, machine.id);
+    await waitForMachineState(app, machine.id, ['started']);
+  }
+}

--- a/tools/infisical/lib/rotate-signature-secret.ts
+++ b/tools/infisical/lib/rotate-signature-secret.ts
@@ -1,0 +1,342 @@
+import { randomBytes, randomUUID } from 'crypto';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import {
+  cancel,
+  confirm,
+  intro,
+  isCancel,
+  note,
+  outro,
+  select,
+  spinner
+} from '@clack/prompts';
+import {
+  type Environment,
+  EnvironmentSchema,
+  deleteInfisicalSecret,
+  setInfisicalSecret,
+  withInfisical
+} from '@codeware/shared/feature/infisical';
+import * as dotenv from 'dotenv';
+
+import { configAppName, fly, restartApp } from './fly-apps';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+dotenv.config({ path: path.join(__dirname, '../.env.infisical') });
+
+const Environments = EnvironmentSchema.options;
+
+/** Folder holding the shared signature secret, imported by web */
+const SECRET_PATH = '/apps/cms/signature';
+const ACTIVE = 'SIGNATURE_SECRET';
+const PREVIOUS = 'SIGNATURE_SECRET_PREVIOUS';
+
+/**
+ * Where the rollover stands, derived from what exists in Infisical.
+ *
+ * There is no stored progress marker - the two secrets are the state:
+ * - no previous            -> nothing started
+ * - previous === active    -> previous is staged, active not yet replaced
+ * - previous !== active    -> active is new, clients are rolling over
+ */
+type Stage = 'not-started' | 'previous-staged' | 'rolling-over';
+
+type State = {
+  stage: Stage;
+  active: string;
+  previous: string | null;
+};
+
+async function readState(environment: Environment): Promise<State> {
+  const secrets = await withInfisical({
+    environment,
+    filter: { path: SECRET_PATH }
+  });
+
+  const value = (key: string) =>
+    secrets?.find(({ secretKey }) => secretKey === key)?.secretValue ?? null;
+
+  const active = value(ACTIVE);
+  const previous = value(PREVIOUS);
+
+  if (!active) {
+    throw new Error(`${ACTIVE} not found in ${SECRET_PATH}`);
+  }
+
+  return {
+    active,
+    previous,
+    stage: !previous
+      ? 'not-started'
+      : previous === active
+        ? 'previous-staged'
+        : 'rolling-over'
+  };
+}
+
+/** Generate a new HMAC signing secret */
+const generateSecret = () => randomBytes(32).toString('hex');
+
+/**
+ * Prove Infisical will accept an edit before any secret is replaced.
+ *
+ * Same reasoning as the tenant key rotation: credentials that cannot write get
+ * partway through and leave cms and web disagreeing about the secret.
+ */
+async function assertInfisicalWritable(
+  environment: Environment
+): Promise<void> {
+  const key = 'ROTATION_WRITE_CHECK';
+  const write = (value: string) =>
+    setInfisicalSecret({ environment, path: SECRET_PATH, key, value });
+
+  try {
+    await write(`probe-${randomUUID()}`);
+
+    const expected = `probe-${randomUUID()}`;
+    await write(expected);
+
+    const stored = (
+      await withInfisical({ environment, filter: { path: SECRET_PATH } })
+    )?.find(({ secretKey }) => secretKey === key)?.secretValue;
+
+    if (stored !== expected) {
+      throw new Error('the edit did not take effect');
+    }
+  } catch (error) {
+    throw new Error(
+      `Infisical will not accept writes at ${SECRET_PATH}: ` +
+        `${error instanceof Error ? error.message : String(error)}`
+    );
+  } finally {
+    await deleteInfisicalSecret({ environment, path: SECRET_PATH, key });
+  }
+}
+
+type AffectedApps = {
+  /** Apps that verify signatures, and must accept a secret before web signs with it */
+  verifiers: Array<string>;
+  /** Apps that sign requests */
+  signers: Array<string>;
+};
+
+/**
+ * Find every deployed app that reads the signature secret.
+ *
+ * cms host verifies, web signs. Tenant-scoped cms deployments are skipped -
+ * they run in tenant mode, where the secret is not part of `APP_MODE`.
+ */
+async function fetchAffectedApps(
+  environment: Environment
+): Promise<AffectedApps> {
+  const names = (await fly.apps.list()).map(({ name }) => name);
+  const cms = configAppName('cms');
+  const web = configAppName('web');
+
+  // Preview apps carry a `-pr-<number>` segment, production apps never do
+  const belongsToEnvironment = (name: string) =>
+    (environment === 'preview') === /-pr-\d+(-|$)/.test(name);
+
+  return {
+    // The host deployment is the base name, with no tenant suffix
+    verifiers: names
+      .filter(
+        (name) =>
+          belongsToEnvironment(name) &&
+          new RegExp(`^${cms}(-pr-\\d+)?$`).test(name)
+      )
+      .sort(),
+    signers: names
+      .filter(
+        (name) => belongsToEnvironment(name) && name.startsWith(`${web}-`)
+      )
+      .sort()
+  };
+}
+
+/**
+ * Main interactive rollover script
+ */
+async function main() {
+  console.clear();
+  intro('🔏  Rotate signature secret');
+
+  const environment = await select<Environment>({
+    message: 'Select environment:',
+    options: Environments.map((env) => ({ value: env, label: env }))
+  });
+
+  if (isCancel(environment)) {
+    cancel('Operation cancelled');
+    process.exit(0);
+  }
+
+  const s = spinner();
+  s.start(`Reading ${SECRET_PATH} for ${environment}...`);
+
+  let state: State;
+  try {
+    state = await readState(environment);
+    s.stop(
+      state.stage === 'not-started'
+        ? 'Current state resolved'
+        : `Resuming a rollover already at '${state.stage}'`
+    );
+  } catch (error) {
+    s.stop('Failed to read secrets');
+    cancel(`Error: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  }
+
+  s.start('Finding apps that use the signature secret...');
+
+  let apps: AffectedApps;
+  try {
+    apps = await fetchAffectedApps(environment);
+    s.stop(
+      `${apps.verifiers.length} verifier(s), ${apps.signers.length} signer(s)`
+    );
+  } catch (error) {
+    s.stop('Failed to list apps');
+    cancel(`Error: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  }
+
+  if (!apps.verifiers.length || !apps.signers.length) {
+    cancel(
+      `Expected both cms and web apps in ${environment}, found ` +
+        `verifiers=[${apps.verifiers.join(', ')}] signers=[${apps.signers.join(', ')}]`
+    );
+    process.exit(1);
+  }
+
+  note(
+    [
+      `The whole rollover runs in one go, restarting apps between steps:`,
+      '',
+      `  1. keep the current secret as ${PREVIOUS}, restart cms`,
+      `  2. generate a new ${ACTIVE}, restart cms then web`,
+      `  3. drop ${PREVIOUS}, restart cms`,
+      '',
+      `cms accepts both secrets throughout, so nothing is rejected while web`,
+      `is catching up. The secret is read from Infisical at boot, so restarting`,
+      `is all it takes - no redeploy.`,
+      '',
+      `verifiers: ${apps.verifiers.join(', ')}`,
+      `signers:   ${apps.signers.join(', ')}`
+    ].join('\n'),
+    `Rollover plan for ${environment}`
+  );
+
+  const proceed = await confirm({
+    message: `Roll over the signature secret in ${environment}?`,
+    initialValue: false
+  });
+
+  if (isCancel(proceed) || !proceed) {
+    cancel('Operation cancelled - nothing was written');
+    process.exit(0);
+  }
+
+  s.start('Checking Infisical accepts writes...');
+
+  try {
+    await assertInfisicalWritable(environment);
+    s.stop('Infisical writes verified');
+  } catch (error) {
+    s.stop('Infisical is not writable');
+    note(
+      [
+        error instanceof Error ? error.message : String(error),
+        '',
+        `Nothing was changed. Rotation needs credentials that can create and`,
+        `edit secrets under ${SECRET_PATH}.`
+      ].join('\n'),
+      '⚠️  Cannot roll over'
+    );
+    process.exit(1);
+  }
+
+  const restartAll = async (names: Array<string>) => {
+    for (const app of names) {
+      s.message(`Restarting ${app}...`);
+      await restartApp(app);
+    }
+  };
+
+  try {
+    // Step 1 - cms starts accepting the current secret as the previous one, so
+    // it keeps working once the active one changes underneath it
+    if (state.stage === 'not-started') {
+      s.start(`Staging ${PREVIOUS}...`);
+      await setInfisicalSecret({
+        environment,
+        path: SECRET_PATH,
+        key: PREVIOUS,
+        value: state.active
+      });
+      await restartAll(apps.verifiers);
+      s.stop(`${PREVIOUS} staged, cms restarted`);
+      state = await readState(environment);
+    }
+
+    // Step 2 - the new secret. cms has to know it before web signs with it,
+    // hence verifiers first
+    if (state.stage === 'previous-staged') {
+      s.start(`Generating a new ${ACTIVE}...`);
+      await setInfisicalSecret({
+        environment,
+        path: SECRET_PATH,
+        key: ACTIVE,
+        value: generateSecret()
+      });
+      await restartAll(apps.verifiers);
+      await restartAll(apps.signers);
+      s.stop(`${ACTIVE} replaced, cms and web restarted`);
+      state = await readState(environment);
+    }
+
+    // Step 3 - only the new secret is accepted from here
+    if (state.stage === 'rolling-over') {
+      s.start(`Retiring ${PREVIOUS}...`);
+      await deleteInfisicalSecret({
+        environment,
+        path: SECRET_PATH,
+        key: PREVIOUS
+      });
+      await restartAll(apps.verifiers);
+      s.stop(`${PREVIOUS} retired, cms restarted`);
+    }
+  } catch (error) {
+    s.stop('Rollover interrupted');
+    note(
+      [
+        error instanceof Error ? error.message : String(error),
+        '',
+        `The rollover stopped partway. Its progress is held in the secrets`,
+        `themselves, so running this again picks up where it left off.`,
+        '',
+        `Until it completes cms may still accept the previous secret, which is`,
+        `the safe direction to be interrupted in.`
+      ].join('\n'),
+      '⚠️  Not finished'
+    );
+    process.exit(1);
+  }
+
+  outro(`✅  Signature secret rolled over in ${environment}`);
+}
+
+// Export for use as a library
+export { main as rotateSignatureSecretMain };
+
+// Run if executed directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error('Unexpected error:', error);
+    process.exit(1);
+  });
+}

--- a/tools/infisical/lib/rotate-tenant-key.ts
+++ b/tools/infisical/lib/rotate-tenant-key.ts
@@ -1,0 +1,288 @@
+import { exec } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { promisify } from 'util';
+
+import {
+  cancel,
+  confirm,
+  intro,
+  isCancel,
+  log,
+  note,
+  outro,
+  select,
+  spinner
+} from '@clack/prompts';
+import {
+  type Environment,
+  EnvironmentSchema,
+  setInfisicalSecret,
+  withInfisical
+} from '@codeware/shared/feature/infisical';
+import { toPoolerUrl } from '@codeware/shared/util/pure';
+import * as dotenv from 'dotenv';
+
+const execAsync = promisify(exec);
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+dotenv.config({ path: path.join(__dirname, '../.env.infisical') });
+
+const Environments = EnvironmentSchema.options;
+
+// Supabase project region — used to construct the Session Mode pooler hostname
+const SUPABASE_REGION = 'eu-central-1';
+
+const workspaceRoot = path.resolve(__dirname, '../../..');
+
+/**
+ * Discover which apps each tenant deploys, from the `/tenants/<id>/apps/<app>`
+ * folder structure. Every app folder holding a `PAYLOAD_API_KEY` has to be
+ * updated, otherwise that deployment authenticates with the retired key.
+ */
+async function fetchTenantApps(
+  environment: Environment
+): Promise<Map<string, Array<string>>> {
+  const folders = await withInfisical({
+    environment,
+    filter: { path: '/tenants', recurse: true },
+    groupByFolder: true
+  });
+
+  const tenantApps = new Map<string, Array<string>>();
+  const tenantAppPattern = /^\/tenants\/([^/]+)\/apps\/([^/]+)$/;
+
+  for (const folder of folders ?? []) {
+    const match = folder.path.match(tenantAppPattern);
+
+    if (!match) {
+      continue;
+    }
+
+    const [, tenantId, appName] = match;
+    const hasApiKey = folder.secrets.some(
+      ({ secretKey }) => secretKey === 'PAYLOAD_API_KEY'
+    );
+
+    if (!hasApiKey) {
+      continue;
+    }
+
+    tenantApps.set(tenantId, [...(tenantApps.get(tenantId) ?? []), appName]);
+  }
+
+  return tenantApps;
+}
+
+/**
+ * Fetch the CMS host DATABASE_URL for an environment
+ */
+async function fetchDatabaseUrl(environment: Environment): Promise<string> {
+  const secrets = await withInfisical({
+    environment,
+    filter: { path: '/apps/cms' }
+  });
+
+  const dbUrl = secrets?.find(
+    ({ secretKey }) => secretKey === 'DATABASE_URL'
+  )?.secretValue;
+
+  if (!dbUrl) {
+    throw new Error(
+      `DATABASE_URL not found in Infisical /apps/cms for environment: ${environment}`
+    );
+  }
+
+  return dbUrl;
+}
+
+/**
+ * Rotate the key in Payload via the local-api and return the new value
+ */
+async function rotateInPayload(
+  tenantId: string,
+  databaseUrl: string
+): Promise<string> {
+  const { stdout } = await execAsync('npx tsx src/utils/rotate-tenant-key.ts', {
+    cwd: path.join(workspaceRoot, 'apps/cms'),
+    env: {
+      ...process.env,
+      DATABASE_URL: databaseUrl,
+      ROTATE_TENANT_SLUG: tenantId,
+      DISABLE_DB_PUSH: 'true',
+      SEED_SOURCE: 'off'
+    }
+  });
+
+  const apiKey = stdout.match(/^ROTATED_API_KEY=(.+)$/m)?.[1]?.trim();
+
+  if (!apiKey) {
+    throw new Error(`Rotation script did not return a key:\n${stdout}`);
+  }
+
+  return apiKey;
+}
+
+/**
+ * Main interactive rotation script
+ */
+async function main() {
+  console.clear();
+  intro('🔑  Rotate tenant API key');
+
+  const environment = await select<Environment>({
+    message: 'Select environment:',
+    options: Environments.map((env) => ({ value: env, label: env }))
+  });
+
+  if (isCancel(environment)) {
+    cancel('Operation cancelled');
+    process.exit(0);
+  }
+
+  const s = spinner();
+
+  s.start(`Fetching tenants for ${environment} from Infisical...`);
+
+  let tenantApps: Map<string, Array<string>>;
+  try {
+    tenantApps = await fetchTenantApps(environment);
+    s.stop(`Found ${tenantApps.size} tenant(s)`);
+  } catch (error) {
+    s.stop('Failed to fetch tenants');
+    cancel(`Error: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  }
+
+  if (tenantApps.size === 0) {
+    cancel(`No tenants with a PAYLOAD_API_KEY found in ${environment}`);
+    process.exit(0);
+  }
+
+  const tenantId = await select<string>({
+    message: 'Select tenant to rotate:',
+    options: [...tenantApps.entries()].map(([tenant, apps]) => ({
+      value: tenant,
+      label: tenant,
+      hint: `${apps.join(', ')}`
+    }))
+  });
+
+  if (isCancel(tenantId)) {
+    cancel('Operation cancelled');
+    process.exit(0);
+  }
+
+  const apps = tenantApps.get(tenantId) ?? [];
+
+  note(
+    [
+      `Payload tenant '${tenantId}' gets a new API key, then Infisical is`,
+      `updated for: ${apps.map((app) => `/tenants/${tenantId}/apps/${app}`).join(', ')}`,
+      '',
+      `The running deployments keep using the old key until they are`,
+      `redeployed, so ${tenantId} serves errors until that completes.`
+    ].join('\n'),
+    'What happens next'
+  );
+
+  const proceed = await confirm({
+    message: `Rotate the API key for '${tenantId}' in ${environment}?`,
+    initialValue: false
+  });
+
+  if (isCancel(proceed) || !proceed) {
+    cancel('Operation cancelled');
+    process.exit(0);
+  }
+
+  s.start(`Fetching DATABASE_URL for ${environment}...`);
+
+  let databaseUrl: string;
+  try {
+    databaseUrl = toPoolerUrl(
+      await fetchDatabaseUrl(environment),
+      SUPABASE_REGION
+    );
+    s.stop('Database URL fetched');
+  } catch (error) {
+    s.stop('Failed to fetch database URL');
+    cancel(`Error: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  }
+
+  s.start(`Rotating key in Payload for '${tenantId}'...`);
+
+  let apiKey: string;
+  try {
+    apiKey = await rotateInPayload(tenantId, databaseUrl);
+    s.stop('Payload tenant updated');
+  } catch (error) {
+    s.stop('Rotation failed');
+    cancel(`Error: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  }
+
+  // From here the Payload key is already live — every Infisical write has to
+  // land or the tenant stays broken with no way back to the old key.
+  const failed: Array<string> = [];
+
+  for (const app of apps) {
+    const secretPath = `/tenants/${tenantId}/apps/${app}`;
+    s.start(`Updating ${secretPath}...`);
+
+    try {
+      const { action } = await setInfisicalSecret({
+        environment,
+        path: secretPath,
+        key: 'PAYLOAD_API_KEY',
+        value: apiKey
+      });
+      s.stop(`${secretPath} ${action}`);
+    } catch (error) {
+      s.stop(`${secretPath} failed`);
+      log.error(error instanceof Error ? error.message : String(error));
+      failed.push(secretPath);
+    }
+  }
+
+  if (failed.length) {
+    note(
+      [
+        `Payload now expects the new key but these paths were not updated:`,
+        ...failed.map((p) => `  ${p}`),
+        '',
+        `Set PAYLOAD_API_KEY manually before redeploying:`,
+        `  ${apiKey}`
+      ].join('\n'),
+      '⚠️  Infisical is out of sync'
+    );
+    process.exit(1);
+  }
+
+  note(
+    [
+      `Redeploy ${tenantId} so the deployments pick up the new key:`,
+      '',
+      `  Actions → Fly Deployment → Run workflow`,
+      `  App: <empty>  Tenant: ${tenantId}  Environment: ${environment}`,
+      '',
+      `Until then ${tenantId} authenticates with the retired key.`
+    ].join('\n'),
+    'Redeploy required'
+  );
+
+  outro(`✅  Rotated API key for '${tenantId}' in ${environment}`);
+}
+
+// Export for use as a library
+export { main as rotateTenantKeyMain };
+
+// Run if executed directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error('Unexpected error:', error);
+    process.exit(1);
+  });
+}

--- a/tools/infisical/lib/rotate-tenant-key.ts
+++ b/tools/infisical/lib/rotate-tenant-key.ts
@@ -1,12 +1,10 @@
 import { type ChildProcess, exec, spawn } from 'child_process';
 import { randomUUID } from 'crypto';
-import { readFileSync } from 'fs';
 import { connect } from 'net';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { promisify } from 'util';
 
-import { Fly } from '@cdwr/fly-node';
 import {
   cancel,
   confirm,
@@ -25,10 +23,10 @@ import {
   setInfisicalSecret,
   withInfisical
 } from '@codeware/shared/feature/infisical';
-import { getAppName } from '@codeware/shared/util/nx-deploy';
 import { toPoolerUrl } from '@codeware/shared/util/pure';
 import * as dotenv from 'dotenv';
-import * as TOML from 'smol-toml';
+
+import { fly, flyAppName, startMachines, workspaceRoot } from './fly-apps';
 
 const execAsync = promisify(exec);
 const __filename = fileURLToPath(import.meta.url);
@@ -40,23 +38,6 @@ const Environments = EnvironmentSchema.options;
 
 // Supabase project region — used to construct the Session Mode pooler hostname
 const SUPABASE_REGION = 'eu-central-1';
-
-const workspaceRoot = path.resolve(__dirname, '../../..');
-
-// Silent client — the ssh output carries a connection string, so nothing from
-// the Fly CLI should reach the console
-const fly = new Fly({
-  logger: {
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    info: () => {},
-    error: console.error,
-    traceCLI: false,
-    redactSecrets: true,
-    verbose: false,
-    debug: false,
-    streamToConsole: false
-  }
-});
 
 type TenantDeployment = {
   /** App folders holding a `PAYLOAD_API_KEY`, all of which must be updated */
@@ -205,60 +186,6 @@ async function assertInfisicalWritable(
     );
   } finally {
     await deleteInfisicalSecret({ environment, path: secretPath, key });
-  }
-}
-
-/**
- * Resolve the Fly app name for a tenant's deployment of an app.
- *
- * The base name lives in the app's own fly config, and `getAppName` applies the
- * same pull request and tenant suffixes the deployment action uses.
- */
-function flyAppName(
-  app: string,
-  tenantId: string,
-  pullRequest?: string
-): string {
-  const configPath = path.join(workspaceRoot, 'apps', app, 'fly.toml');
-  const config = TOML.parse(readFileSync(configPath, 'utf-8')) as {
-    app?: string;
-  };
-
-  if (!config.app) {
-    throw new Error(`No app name found in ${configPath}`);
-  }
-
-  return getAppName({
-    configAppName: config.app,
-    environment: pullRequest ? 'preview' : 'production',
-    pullRequest: pullRequest ? Number(pullRequest) : undefined,
-    tenantId
-  });
-}
-
-/**
- * Start every machine of an app that is not already running.
- *
- * Preview machines suspend when idle, and Fly can neither ssh into nor update
- * a machine that is not started.
- */
-async function startMachines(app: string): Promise<void> {
-  const status = await fly.status({ app });
-  const machines = status?.machines ?? [];
-
-  if (!machines.length) {
-    throw new Error(`App '${app}' has no machines - is it deployed?`);
-  }
-
-  const stopped = machines.filter(({ state }) => state !== 'started');
-
-  for (const machine of stopped) {
-    await fly.machines.start(app, machine.id);
-  }
-
-  if (stopped.length) {
-    // Give them a moment to accept connections
-    await new Promise((resolve) => setTimeout(resolve, 5_000));
   }
 }
 

--- a/tools/infisical/lib/rotate-tenant-key.ts
+++ b/tools/infisical/lib/rotate-tenant-key.ts
@@ -1,8 +1,12 @@
-import { exec } from 'child_process';
+import { type ChildProcess, exec, spawn } from 'child_process';
+import { randomUUID } from 'crypto';
+import { readFileSync } from 'fs';
+import { connect } from 'net';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { promisify } from 'util';
 
+import { Fly } from '@cdwr/fly-node';
 import {
   cancel,
   confirm,
@@ -17,11 +21,14 @@ import {
 import {
   type Environment,
   EnvironmentSchema,
+  deleteInfisicalSecret,
   setInfisicalSecret,
   withInfisical
 } from '@codeware/shared/feature/infisical';
+import { getAppName } from '@codeware/shared/util/nx-deploy';
 import { toPoolerUrl } from '@codeware/shared/util/pure';
 import * as dotenv from 'dotenv';
+import * as TOML from 'smol-toml';
 
 const execAsync = promisify(exec);
 const __filename = fileURLToPath(import.meta.url);
@@ -36,21 +43,46 @@ const SUPABASE_REGION = 'eu-central-1';
 
 const workspaceRoot = path.resolve(__dirname, '../../..');
 
+// Silent client — the ssh output carries a connection string, so nothing from
+// the Fly CLI should reach the console
+const fly = new Fly({
+  logger: {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    info: () => {},
+    error: console.error,
+    traceCLI: false,
+    redactSecrets: true,
+    verbose: false,
+    debug: false,
+    streamToConsole: false
+  }
+});
+
+type TenantDeployment = {
+  /** App folders holding a `PAYLOAD_API_KEY`, all of which must be updated */
+  apps: Array<string>;
+  /** Distinct key values found across those folders */
+  apiKeys: Set<string>;
+};
+
 /**
  * Discover which apps each tenant deploys, from the `/tenants/<id>/apps/<app>`
  * folder structure. Every app folder holding a `PAYLOAD_API_KEY` has to be
  * updated, otherwise that deployment authenticates with the retired key.
+ *
+ * The key value is collected too - it is what identifies the Payload tenant.
+ * The Infisical tenant id is a deployment name, not the tenant's slug.
  */
-async function fetchTenantApps(
+async function fetchTenantDeployments(
   environment: Environment
-): Promise<Map<string, Array<string>>> {
+): Promise<Map<string, TenantDeployment>> {
   const folders = await withInfisical({
     environment,
     filter: { path: '/tenants', recurse: true },
     groupByFolder: true
   });
 
-  const tenantApps = new Map<string, Array<string>>();
+  const tenants = new Map<string, TenantDeployment>();
   const tenantAppPattern = /^\/tenants\/([^/]+)\/apps\/([^/]+)$/;
 
   for (const folder of folders ?? []) {
@@ -61,26 +93,31 @@ async function fetchTenantApps(
     }
 
     const [, tenantId, appName] = match;
-    const hasApiKey = folder.secrets.some(
+    const apiKey = folder.secrets.find(
       ({ secretKey }) => secretKey === 'PAYLOAD_API_KEY'
-    );
+    )?.secretValue;
 
-    if (!hasApiKey) {
+    if (!apiKey) {
       continue;
     }
 
-    tenantApps.set(tenantId, [...(tenantApps.get(tenantId) ?? []), appName]);
+    const entry = tenants.get(tenantId) ?? { apps: [], apiKeys: new Set() };
+    entry.apps.push(appName);
+    entry.apiKeys.add(apiKey);
+    tenants.set(tenantId, entry);
   }
 
-  return tenantApps;
+  return tenants;
 }
 
 /**
- * Fetch the CMS host DATABASE_URL for an environment
+ * Resolve the production DATABASE_URL from Infisical.
+ *
+ * Production runs on Supabase, so the connection string is a managed secret.
  */
-async function fetchDatabaseUrl(environment: Environment): Promise<string> {
+async function fetchProductionDatabaseUrl(): Promise<string> {
   const secrets = await withInfisical({
-    environment,
+    environment: 'production',
     filter: { path: '/apps/cms' }
   });
 
@@ -89,8 +126,38 @@ async function fetchDatabaseUrl(environment: Environment): Promise<string> {
   )?.secretValue;
 
   if (!dbUrl) {
+    throw new Error('DATABASE_URL not found in Infisical /apps/cms');
+  }
+
+  return toPoolerUrl(dbUrl, SUPABASE_REGION);
+}
+
+/**
+ * Resolve a preview DATABASE_URL from the selected cms app.
+ *
+ * Preview databases are created by `fly postgres attach` during deploy, so the
+ * connection string only exists as a Fly secret on the app itself - it is not
+ * in Infisical and `fly secrets list` returns digests, not values. The only way
+ * to read it back is from inside a running machine.
+ *
+ * All cms apps for a pull request share one database (`flyPostgresDatabaseName`),
+ * so the host app is enough - the tenant-suffixed apps point at the same place.
+ */
+async function fetchPreviewDatabaseUrl(app: string): Promise<string> {
+  await startMachines(app);
+
+  // `fly ssh console` prepends its own chatter when it picks a machine for you
+  // ("No machine specified, using ..."), so take the line that is the value
+  // rather than assuming the output is only the value
+  const output = await fly.ssh.exec(app, 'printenv DATABASE_URL');
+  const dbUrl = output
+    .split('\n')
+    .map((line) => line.trim())
+    .find((line) => line.startsWith('postgres'));
+
+  if (!dbUrl) {
     throw new Error(
-      `DATABASE_URL not found in Infisical /apps/cms for environment: ${environment}`
+      `Could not read DATABASE_URL from app '${app}':\n${output.trim()}`
     );
   }
 
@@ -98,30 +165,398 @@ async function fetchDatabaseUrl(environment: Environment): Promise<string> {
 }
 
 /**
+ * Prove Infisical will accept an edit, before anything is rotated.
+ *
+ * Rotation writes Payload first and Infisical second, so a token that cannot
+ * edit leaves the tenant holding a key nothing else knows. Checking up front
+ * turns that into a refusal to start.
+ *
+ * It has to be a real edit of a real secret: writing `PAYLOAD_API_KEY` back
+ * unchanged proves nothing, because a write that "fails" but leaves the stored
+ * value matching is treated as success. So use a throwaway secret, change it,
+ * confirm the change is visible, and remove it.
+ */
+async function assertInfisicalWritable(
+  environment: Environment,
+  secretPath: string
+): Promise<void> {
+  const key = 'ROTATION_WRITE_CHECK';
+  const write = (value: string) =>
+    setInfisicalSecret({ environment, path: secretPath, key, value });
+
+  try {
+    await write(`probe-${randomUUID()}`);
+
+    // The edit, which is the permission rotation actually needs
+    const expected = `probe-${randomUUID()}`;
+    await write(expected);
+
+    const stored = (
+      await withInfisical({ environment, filter: { path: secretPath } })
+    )?.find(({ secretKey }) => secretKey === key)?.secretValue;
+
+    if (stored !== expected) {
+      throw new Error('the edit did not take effect');
+    }
+  } catch (error) {
+    throw new Error(
+      `Infisical will not accept writes at ${secretPath}: ` +
+        `${error instanceof Error ? error.message : String(error)}`
+    );
+  } finally {
+    await deleteInfisicalSecret({ environment, path: secretPath, key });
+  }
+}
+
+/**
+ * Resolve the Fly app name for a tenant's deployment of an app.
+ *
+ * The base name lives in the app's own fly config, and `getAppName` applies the
+ * same pull request and tenant suffixes the deployment action uses.
+ */
+function flyAppName(
+  app: string,
+  tenantId: string,
+  pullRequest?: string
+): string {
+  const configPath = path.join(workspaceRoot, 'apps', app, 'fly.toml');
+  const config = TOML.parse(readFileSync(configPath, 'utf-8')) as {
+    app?: string;
+  };
+
+  if (!config.app) {
+    throw new Error(`No app name found in ${configPath}`);
+  }
+
+  return getAppName({
+    configAppName: config.app,
+    environment: pullRequest ? 'preview' : 'production',
+    pullRequest: pullRequest ? Number(pullRequest) : undefined,
+    tenantId
+  });
+}
+
+/**
+ * Start every machine of an app that is not already running.
+ *
+ * Preview machines suspend when idle, and Fly can neither ssh into nor update
+ * a machine that is not started.
+ */
+async function startMachines(app: string): Promise<void> {
+  const status = await fly.status({ app });
+  const machines = status?.machines ?? [];
+
+  if (!machines.length) {
+    throw new Error(`App '${app}' has no machines - is it deployed?`);
+  }
+
+  const stopped = machines.filter(({ state }) => state !== 'started');
+
+  for (const machine of stopped) {
+    await fly.machines.start(app, machine.id);
+  }
+
+  if (stopped.length) {
+    // Give them a moment to accept connections
+    await new Promise((resolve) => setTimeout(resolve, 5_000));
+  }
+}
+
+/**
+ * List the cms host apps deployed for open pull requests
+ */
+async function fetchPreviewCmsApps(): Promise<Array<string>> {
+  const apps = await fly.apps.list();
+
+  return apps
+    .map(({ name }) => name)
+    .filter((name) => /-pr-\d+$/.test(name) && name.includes('cms'))
+    .sort();
+}
+
+/** Local port used for the Fly proxy tunnel */
+const PROXY_PORT = 15432;
+
+/** How many times to rebuild the tunnel before giving up */
+const TUNNEL_ATTEMPTS = 5;
+
+/** Whether a connection string points at a Fly private network address */
+const isFlyPrivateUrl = (dbUrl: string) =>
+  /\.(flycast|internal)$/.test(new URL(dbUrl).hostname);
+
+/** Whether something is already accepting connections on a local port */
+const isPortOpen = (port: number) =>
+  new Promise<boolean>((resolve) => {
+    const socket = connect({ host: '127.0.0.1', port })
+      .on('connect', () => {
+        socket.destroy();
+        resolve(true);
+      })
+      .on('error', () => resolve(false));
+  });
+
+/**
+ * Whether a Postgres server actually answers on a local port.
+ *
+ * `fly proxy` opens its listener immediately, well before the remote is
+ * reachable, so an accepted TCP connection proves nothing. Handing that to
+ * Payload is worse than waiting: its connect helper swallows the failure
+ * (`catch (ignore)`) and returns, so the script would end with no logs, no
+ * error and a success exit code.
+ *
+ * Send a Postgres SSLRequest and require the single-byte reply a real server
+ * gives. No client library needed for a handshake this small.
+ */
+const isPostgresReady = (port: number) =>
+  new Promise<boolean>((resolve) => {
+    const socket = connect({ host: '127.0.0.1', port });
+    let settled = false;
+
+    // An explicit timer, because `socket.setTimeout` only covers inactivity
+    // after connecting - a connect that never completes would leave this
+    // promise pending forever, and a pending promise with no handles left is
+    // how a Node process exits 0 having done nothing at all
+    const deadline = setTimeout(() => done(false), 5_000);
+
+    const done = (ready: boolean) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(deadline);
+      socket.destroy();
+      resolve(ready);
+    };
+
+    socket.setTimeout(3_000);
+    socket.on('connect', () => {
+      const sslRequest = Buffer.alloc(8);
+      sslRequest.writeInt32BE(8, 0);
+      sslRequest.writeInt32BE(80877103, 4);
+      socket.write(sslRequest);
+    });
+    // 'S' (ssl supported) or 'N' (not) - either means a Postgres server
+    socket.on('data', (data) => done(data[0] === 0x53 || data[0] === 0x4e));
+    socket.on('timeout', () => done(false));
+    socket.on('error', () => done(false));
+    socket.on('close', () => done(false));
+  });
+
+/** Wait until the tunnel carries a working Postgres connection */
+async function waitForPostgres(
+  port: number,
+  proxy: ChildProcess,
+  timeoutMs = 30_000
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    // A proxy that died is never going to serve the port, and `fly proxy` exits
+    // immediately when the port is taken or the app is unreachable
+    if (proxy.exitCode !== null || proxy.signalCode !== null) {
+      throw new Error(
+        `Fly proxy exited before opening port ${port} (code ${proxy.exitCode ?? proxy.signalCode})`
+      );
+    }
+
+    if (await isPostgresReady(port)) {
+      return;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+
+  throw new Error(
+    `Fly proxy never carried a Postgres connection on port ${port}`
+  );
+}
+
+/**
+ * Run `fn` against the database, tunnelling first when it is only reachable
+ * from inside Fly (`<pg-app>.flycast`).
+ *
+ * Deliberately per operation rather than one tunnel around the whole rotation.
+ * A tunnel held open across a confirmation prompt goes stale while it waits,
+ * and Payload's connect helper swallows the resulting failure - the script then
+ * ends with no output and an exit code of 0.
+ */
+async function withDatabase<T>(
+  databaseUrl: string,
+  fn: (dbUrl: string) => Promise<T>,
+  onRetry?: (attempt: number) => void
+): Promise<T> {
+  const run = () => {
+    if (!isFlyPrivateUrl(databaseUrl)) {
+      return fn(databaseUrl);
+    }
+
+    const url = new URL(databaseUrl);
+    const pgApp = url.hostname.replace(/\.(flycast|internal)$/, '');
+
+    return withFlyProxy(pgApp, url.port || '5432', (localPort) => {
+      url.hostname = '127.0.0.1';
+      url.port = String(localPort);
+      return fn(url.toString());
+    });
+  };
+
+  // A fresh tunnel can pass the readiness probe and still drop the connection
+  // the script then opens - observed needing three goes - so retry with a new
+  // proxy each time. Only failures that happen before the script reaches the
+  // tenant are retried, so this can never repeat a write.
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await run();
+    } catch (error) {
+      if (attempt >= TUNNEL_ATTEMPTS || !isPreWriteFailure(error)) {
+        throw error;
+      }
+
+      onRetry?.(attempt);
+      await new Promise((resolve) => setTimeout(resolve, 2_000));
+    }
+  }
+}
+
+/**
+ * Whether a failure happened before the script touched the tenant.
+ *
+ * The script reports `RESOLVED_TENANT` as soon as it has found the tenant and
+ * `ROTATED_API_KEY` once it has written, so a failure carrying neither means
+ * it never got past connecting - nothing was changed and retrying is safe.
+ */
+const isPreWriteFailure = (error: unknown): boolean => {
+  const message = error instanceof Error ? error.message : String(error);
+
+  return (
+    !message.includes('RESOLVED_TENANT=') &&
+    !message.includes('ROTATED_API_KEY=') &&
+    /exited early|did not report a result/.test(message)
+  );
+};
+
+/**
+ * Run `fn` with a Fly proxy tunnelling the Postgres app to localhost.
+ *
+ * Preview databases are only routable inside the Fly private network
+ * (`<pg-app>.flycast`), so a local process cannot reach them without a tunnel.
+ */
+async function withFlyProxy<T>(
+  pgApp: string,
+  remotePort: string,
+  fn: (localPort: number) => Promise<T>
+): Promise<T> {
+  // Refuse to reuse a port something else is already serving. Waiting on an
+  // open port would otherwise succeed instantly and point the rotation at
+  // whatever is listening, which could be a different database entirely.
+  if (await isPortOpen(PROXY_PORT)) {
+    throw new Error(
+      `Port ${PROXY_PORT} is already in use - close it before rotating, ` +
+        'the tunnel must be the only thing listening there'
+    );
+  }
+
+  const proxy = spawn(
+    'flyctl',
+    ['proxy', `${PROXY_PORT}:${remotePort}`, '--app', pgApp],
+    { stdio: 'ignore' }
+  );
+
+  try {
+    await waitForPostgres(PROXY_PORT, proxy);
+
+    // The probe above opens and drops a connection of its own. Give the proxy a
+    // breath to re-establish before handing it something that matters.
+    await new Promise((resolve) => setTimeout(resolve, 2_000));
+
+    return await fn(PROXY_PORT);
+  } finally {
+    proxy.kill();
+
+    // Killing the proxy does not free the port straight away, and the next
+    // tunnel refuses to start while something is still listening
+    const deadline = Date.now() + 15_000;
+    while (Date.now() < deadline && (await isPortOpen(PROXY_PORT))) {
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+  }
+}
+
+/**
  * Rotate the key in Payload via the local-api and return the new value
  */
 async function rotateInPayload(
-  tenantId: string,
-  databaseUrl: string
-): Promise<string> {
-  const { stdout } = await execAsync('npx tsx src/utils/rotate-tenant-key.ts', {
-    cwd: path.join(workspaceRoot, 'apps/cms'),
-    env: {
-      ...process.env,
-      DATABASE_URL: databaseUrl,
-      ROTATE_TENANT_SLUG: tenantId,
-      DISABLE_DB_PUSH: 'true',
-      SEED_SOURCE: 'off'
+  environment: Environment,
+  currentApiKey: string,
+  databaseUrl: string,
+  dryRun = false
+): Promise<{ apiKey: string; slug: string }> {
+  // This CLI runs under `tsx --tsconfig tools/tsconfig.tools.json`, which
+  // exports its own instrumentation for child processes: the tsconfig path
+  // (relative, so the child resolves it against `apps/cms` and dies) and a
+  // NODE_PATH pointing into tsx's bundled node_modules, which quietly changes
+  // how the child resolves modules. The child runs its own `npx tsx` and needs
+  // none of it, so drop the lot rather than inherit a half-applied setup.
+  const {
+    TSX_TSCONFIG_PATH: _tsconfig,
+    NODE_PATH: _nodePath,
+    NODE_OPTIONS: _nodeOptions,
+    ...parentEnv
+  } = process.env;
+
+  const { stdout, stderr } = await execAsync(
+    'npx tsx src/utils/rotate-tenant-key.ts',
+    {
+      cwd: path.join(workspaceRoot, 'apps/cms'),
+      env: {
+        ...parentEnv,
+        // The target environment decides which PAYLOAD_SECRET_KEY is loaded, and
+        // that key encrypts the API key - inheriting the local one would write a
+        // value the deployment cannot decrypt
+        DEPLOY_ENV: environment,
+        // Rotation is a host-mode operation across all tenants
+        TENANT_ID: '',
+        // Normally injected by the deployment action, and required by the env
+        // schema even though a local rotation does not use them
+        APP_NAME: 'cdwr-cms',
+        FLY_URL: '',
+        PR_NUMBER: '',
+        ROTATE_DATABASE_URL: databaseUrl,
+        ROTATE_CURRENT_API_KEY: currentApiKey,
+        ROTATE_DRY_RUN: String(dryRun),
+        DISABLE_DB_PUSH: 'true',
+        SEED_SOURCE: 'off'
+      }
     }
-  });
+  );
 
-  const apiKey = stdout.match(/^ROTATED_API_KEY=(.+)$/m)?.[1]?.trim();
+  const apiKey = stdout.match(/^ROTATED_API_KEY=(.+)$/m)?.[1]?.trim() ?? '';
+  const slug = stdout.match(/^RESOLVED_TENANT=(.+)$/m)?.[1]?.trim();
 
-  if (!apiKey) {
-    throw new Error(`Rotation script did not return a key:\n${stdout}`);
+  if (!slug || (!dryRun && !apiKey)) {
+    // The key may already have been written and printed before whatever went
+    // wrong here, and this output ends up on a console and in shell history.
+    // Keep the marker, drop the value - `isPreWriteFailure` reads the marker
+    // to decide whether a retry could repeat a write.
+    const redact = (output: string) =>
+      output.replace(/^(ROTATED_API_KEY=).*$/gm, '$1<redacted>');
+
+    // Report both streams - the interesting part of a silent failure is
+    // usually on stderr, and without it there is nothing to go on
+    throw new Error(
+      [
+        'Rotation script did not report a result.',
+        '',
+        '--- stdout ---',
+        redact(stdout.trim()) || '<empty>',
+        '',
+        '--- stderr ---',
+        redact(stderr.trim()) || '<empty>'
+      ].join('\n')
+    );
   }
 
-  return apiKey;
+  return { apiKey, slug };
 }
 
 /**
@@ -143,26 +578,63 @@ async function main() {
 
   const s = spinner();
 
+  // Preview has one database per pull request, so the app has to be named
+  // before anything can be read from it
+  let previewApp = '';
+
+  if (environment === 'preview') {
+    s.start('Listing preview cms apps...');
+
+    let previewApps: Array<string>;
+    try {
+      previewApps = await fetchPreviewCmsApps();
+      s.stop(`Found ${previewApps.length} preview cms app(s)`);
+    } catch (error) {
+      s.stop('Failed to list apps');
+      cancel(
+        `Error: ${error instanceof Error ? error.message : String(error)}`
+      );
+      process.exit(1);
+    }
+
+    if (!previewApps.length) {
+      cancel('No preview cms apps are deployed');
+      process.exit(0);
+    }
+
+    const selected = await select<string>({
+      message: 'Select the cms app holding the preview database:',
+      options: previewApps.map((app) => ({ value: app, label: app }))
+    });
+
+    if (isCancel(selected)) {
+      cancel('Operation cancelled');
+      process.exit(0);
+    }
+
+    previewApp = selected;
+  }
+
   s.start(`Fetching tenants for ${environment} from Infisical...`);
 
-  let tenantApps: Map<string, Array<string>>;
+  let tenants: Map<string, TenantDeployment>;
   try {
-    tenantApps = await fetchTenantApps(environment);
-    s.stop(`Found ${tenantApps.size} tenant(s)`);
+    tenants = await fetchTenantDeployments(environment);
+    s.stop(`Found ${tenants.size} tenant(s)`);
   } catch (error) {
     s.stop('Failed to fetch tenants');
     cancel(`Error: ${error instanceof Error ? error.message : String(error)}`);
     process.exit(1);
   }
 
-  if (tenantApps.size === 0) {
+  if (tenants.size === 0) {
     cancel(`No tenants with a PAYLOAD_API_KEY found in ${environment}`);
     process.exit(0);
   }
 
   const tenantId = await select<string>({
     message: 'Select tenant to rotate:',
-    options: [...tenantApps.entries()].map(([tenant, apps]) => ({
+    options: [...tenants.entries()].map(([tenant, { apps }]) => ({
       value: tenant,
       label: tenant,
       hint: `${apps.join(', ')}`
@@ -174,12 +646,37 @@ async function main() {
     process.exit(0);
   }
 
-  const apps = tenantApps.get(tenantId) ?? [];
+  const { apps, apiKeys } = tenants.get(tenantId) ?? {
+    apps: [],
+    apiKeys: new Set<string>()
+  };
+
+  // The key identifies the tenant, so the folders disagreeing means we cannot
+  // know which one the deployments actually authenticate with
+  if (apiKeys.size > 1) {
+    cancel(
+      `The app folders under /tenants/${tenantId} hold different ` +
+        `PAYLOAD_API_KEY values. Reconcile them before rotating.`
+    );
+    process.exit(1);
+  }
+
+  const [currentApiKey] = [...apiKeys];
 
   note(
     [
-      `Payload tenant '${tenantId}' gets a new API key, then Infisical is`,
+      `The Payload tenant using this key gets a new one, then Infisical is`,
       `updated for: ${apps.map((app) => `/tenants/${tenantId}/apps/${app}`).join(', ')}`,
+      '',
+      `'${tenantId}' is a deployment name - the tenant is resolved by its`,
+      `current API key, and its Payload slug is reported once resolved.`,
+      ...(previewApp
+        ? [
+            '',
+            `Database is read from '${previewApp}', which is started first if`,
+            `its machines are stopped.`
+          ]
+        : []),
       '',
       `The running deployments keep using the old key until they are`,
       `redeployed, so ${tenantId} serves errors until that completes.`
@@ -187,37 +684,96 @@ async function main() {
     'What happens next'
   );
 
-  const proceed = await confirm({
-    message: `Rotate the API key for '${tenantId}' in ${environment}?`,
-    initialValue: false
-  });
-
-  if (isCancel(proceed) || !proceed) {
-    cancel('Operation cancelled');
-    process.exit(0);
-  }
-
-  s.start(`Fetching DATABASE_URL for ${environment}...`);
+  s.start(
+    previewApp
+      ? `Reading DATABASE_URL from '${previewApp}'...`
+      : 'Fetching DATABASE_URL from Infisical...'
+  );
 
   let databaseUrl: string;
   try {
-    databaseUrl = toPoolerUrl(
-      await fetchDatabaseUrl(environment),
-      SUPABASE_REGION
-    );
-    s.stop('Database URL fetched');
+    databaseUrl = previewApp
+      ? await fetchPreviewDatabaseUrl(previewApp)
+      : await fetchProductionDatabaseUrl();
+    s.stop('Database URL resolved');
   } catch (error) {
-    s.stop('Failed to fetch database URL');
+    s.stop('Failed to resolve database URL');
     cancel(`Error: ${error instanceof Error ? error.message : String(error)}`);
     process.exit(1);
   }
 
-  s.start(`Rotating key in Payload for '${tenantId}'...`);
+  // Both stores have to be writable for a rotation to finish. Payload is
+  // written first, so an Infisical token that cannot edit would leave the
+  // tenant holding a key nothing else has - check before that can happen.
+  s.start('Checking Infisical accepts writes...');
 
-  let apiKey: string;
   try {
-    apiKey = await rotateInPayload(tenantId, databaseUrl);
-    s.stop('Payload tenant updated');
+    for (const app of apps) {
+      await assertInfisicalWritable(
+        environment,
+        `/tenants/${tenantId}/apps/${app}`
+      );
+    }
+    s.stop('Infisical writes verified');
+  } catch (error) {
+    s.stop('Infisical is not writable');
+    note(
+      [
+        error instanceof Error ? error.message : String(error),
+        '',
+        `Nothing was changed - Payload is untouched and the tenant still works.`,
+        '',
+        `Rotation writes to Infisical, so the credentials in`,
+        `tools/infisical/.env.infisical need to create and edit secrets under`,
+        `/tenants. A read-only token gets this far and then strands the tenant`,
+        `on a key only Payload knows, which is why it is checked up front.`
+      ].join('\n'),
+      '⚠️  Cannot rotate'
+    );
+    process.exit(1);
+  }
+
+  // Resolve first, so the tenant being rotated is named before anything is
+  // written. This connects on its own - see `withDatabase` for why the
+  // connection is not held open across the prompt that follows.
+  s.start('Resolving which Payload tenant holds this key...');
+
+  let slug: string;
+  try {
+    ({ slug } = await withDatabase(
+      databaseUrl,
+      (dbUrl) => rotateInPayload(environment, currentApiKey, dbUrl, true),
+      (attempt) =>
+        s.message(`Tunnel dropped, rebuilding (attempt ${attempt + 1})...`)
+    ));
+    s.stop(`Resolved to Payload tenant '${slug}'`);
+  } catch (error) {
+    s.stop('Could not resolve the tenant');
+    cancel(`Error: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  }
+
+  const proceed = await confirm({
+    message: `Rotate '${tenantId}' → Payload tenant '${slug}' in ${environment}?`,
+    initialValue: false
+  });
+
+  if (isCancel(proceed) || !proceed) {
+    cancel('Operation cancelled - nothing was written');
+    process.exit(0);
+  }
+
+  s.start(`Rotating key for '${slug}'...`);
+
+  let rotated: { apiKey: string; slug: string };
+  try {
+    rotated = await withDatabase(
+      databaseUrl,
+      (dbUrl) => rotateInPayload(environment, currentApiKey, dbUrl),
+      (attempt) =>
+        s.message(`Tunnel dropped, rebuilding (attempt ${attempt + 1})...`)
+    );
+    s.stop(`Payload tenant '${rotated.slug}' updated`);
   } catch (error) {
     s.stop('Rotation failed');
     cancel(`Error: ${error instanceof Error ? error.message : String(error)}`);
@@ -237,7 +793,7 @@ async function main() {
         environment,
         path: secretPath,
         key: 'PAYLOAD_API_KEY',
-        value: apiKey
+        value: rotated.apiKey
       });
       s.stop(`${secretPath} ${action}`);
     } catch (error) {
@@ -254,26 +810,80 @@ async function main() {
         ...failed.map((p) => `  ${p}`),
         '',
         `Set PAYLOAD_API_KEY manually before redeploying:`,
-        `  ${apiKey}`
+        `  ${rotated.apiKey}`
       ].join('\n'),
       '⚠️  Infisical is out of sync'
     );
     process.exit(1);
   }
 
-  note(
-    [
-      `Redeploy ${tenantId} so the deployments pick up the new key:`,
-      '',
-      `  Actions → Fly Deployment → Run workflow`,
-      `  App: <empty>  Tenant: ${tenantId}  Environment: ${environment}`,
-      '',
-      `Until then ${tenantId} authenticates with the retired key.`
-    ].join('\n'),
-    'Redeploy required'
-  );
+  // A redeploy would not finish the job: the deployment only sets secrets that
+  // are missing and skips any that already exist, so a rotated PAYLOAD_API_KEY
+  // never reaches a running app that way. Write it to the Fly apps directly.
+  const pullRequest = previewApp.match(/-pr-(\d+)$/)?.[1];
+  const flyApps = apps.map((app) => ({
+    app,
+    flyApp: flyAppName(app, tenantId, pullRequest)
+  }));
 
-  outro(`✅  Rotated API key for '${tenantId}' in ${environment}`);
+  // Stage everywhere first, then apply, so cms and web change together instead
+  // of each restarting as its own secret lands
+  const staged: Array<string> = [];
+
+  for (const { app, flyApp } of flyApps) {
+    s.start(`Staging PAYLOAD_API_KEY on ${flyApp}...`);
+
+    try {
+      await fly.secrets.set(
+        { PAYLOAD_API_KEY: rotated.apiKey },
+        { app: flyApp, stage: true }
+      );
+      staged.push(flyApp);
+      s.stop(`${flyApp} staged`);
+    } catch (error) {
+      s.stop(`${flyApp} could not be staged`);
+      log.error(error instanceof Error ? error.message : String(error));
+      note(
+        [
+          `Infisical holds the new key, but '${flyApp}' (${app}) did not take`,
+          `it. Nothing has been applied yet, so the tenant is still running on`,
+          `the old key - finish the remaining apps by hand:`,
+          '',
+          `  fly secrets set PAYLOAD_API_KEY=<key> --app ${flyApp}`
+        ].join('\n'),
+        '⚠️  Staging incomplete'
+      );
+      process.exit(1);
+    }
+  }
+
+  for (const flyApp of staged) {
+    s.start(`Applying staged secret on ${flyApp}...`);
+
+    try {
+      // Fly can only update a started machine, and preview machines suspend
+      await startMachines(flyApp);
+      await fly.secrets.deploy(flyApp);
+      s.stop(`${flyApp} restarted with the new key`);
+    } catch (error) {
+      s.stop(`${flyApp} could not be restarted`);
+      log.error(error instanceof Error ? error.message : String(error));
+      note(
+        [
+          `The secret is staged on '${flyApp}' but not applied. Its machines`,
+          `keep the old key until they take it up:`,
+          '',
+          `  fly secrets deploy --app ${flyApp}`
+        ].join('\n'),
+        '⚠️  Apply incomplete'
+      );
+      process.exit(1);
+    }
+  }
+
+  outro(
+    `✅  Rotated API key for '${tenantId}' (tenant '${rotated.slug}') in ${environment}`
+  );
 }
 
 // Export for use as a library


### PR DESCRIPTION
Covers both secrets leaked in COD-422, behind one consistent CLI surface: `pnpm cdwr` → `rotate-tenant-key` and `rotate-signature-secret`.

> [!IMPORTANT]
> Merge **after #464**. The signature command writes `SIGNATURE_SECRET_PREVIOUS`, which only has runtime meaning once cms accepts it, and #464's `docs/DEPLOYMENT.md` already points here.

## rotate-tenant-key

Rotation was never actually blocked by COD-399 — that ticket blocks the *admin* affordance. The `apiKey` field is `update: () => false` for REST/GraphQL/admin only, and the local-api bypasses it with `overrideAccess`.

The key lives in two places that must move together: the Payload tenant document (source of truth) and Infisical under every `/tenants/<id>/apps/<app>` that deploys it. Discovering app folders from Infisical means a tenant that also runs cms in tenant mode gets both updated — `resolveScopedTenant` reads the same key.

**No zero-downtime path exists** — Payload stores one key per tenant document. The confirmation prompt states this before anything is written. If an Infisical write fails after Payload is updated, the tool prints the new key and the unwritten paths; there is no going back to the old key at that point.

### Reaching the database

The bulk of the work, and it differs per environment:

- **Production** runs on Supabase, so `DATABASE_URL` is an Infisical secret, rewritten to the Session Mode pooler host.
- **Preview** databases come from `fly postgres attach` at deploy time, so the URL exists only as a Fly secret on that PR's cms app — not in Infisical, and `fly secrets list` returns digests, not values. The tool asks which cms app to use, starts a machine if all are suspended, reads the URL from inside it over SSH, then opens a `fly proxy` tunnel since the host is a private `.flycast` address.

Three ordering bugs surfaced while testing against a live preview:

- `loadEnv()` injects Infisical values **over** `process.env`, so the caller's `DATABASE_URL` was silently replaced by the deployment's own unreachable host. Now set both before (preview has none, so the env would not validate) and after (production does, and would overwrite).
- The same overwrite re-enabled `SEED_SOURCE` and `DISABLE_DB_PUSH`, so a rotation **seeded the database and would have pushed schema**. Both forced off after loading.
- The child inherits `TSX_TSCONFIG_PATH` from the CLI's own `tsx --tsconfig`, resolved it against `apps/cms` and died. Stripped.

## rotate-signature-secret

The manual procedure was four stateful steps with a redeploy between each — easy to half-complete and leave every tenant site failing. There is no progress marker to store because the two secrets *are* the state:

| `SIGNATURE_SECRET_PREVIOUS` | Stage | Next step |
| --- | --- | --- |
| absent | not started | stage the current secret |
| same as active | staged | generate a new active secret |
| differs from active | rolling over | retire the previous secret |

The command reads the folder, derives the stage, describes exactly what the step does and which redeploy follows, then applies only that one step. Run it again after each redeploy.

Step 3 is deliberately a no-op write — it exists so the tool tells you to redeploy web before offering the destructive step 4, which breaks any deployment still signing with the old secret.

## Changes

- `setInfisicalSecret` / `deleteInfisicalSecret` in `libs/shared/feature/infisical` — the lib was read-only; client creation extracted to a shared helper
- `ssh.exec` in `@cdwr/fly-node` — thin wrapper over `fly ssh console --command`
- `apps/cms/src/utils/rotate-tenant-key.ts` — local-api rotation; imports the config *after* `loadEnv` because it reads `getEnv()` at module scope and nothing pre-loads `.env.local` outside Nx
- Two interactive commands in `tools/infisical/lib/`, registered in `cdwr-cli.ts`
- `toPoolerUrl` moved to `@codeware/shared/util/pure` (with a spec) so both tools use it without crossing Nx project boundaries
- Both procedures documented in `docs/DEPLOYMENT.md`

## Test plan

- **Tenant key, verified end-to-end** against the live `cdwr-cms-pr-465` preview: started a suspended machine, read `DATABASE_URL` over SSH, opened the tunnel, booted Payload against the preview database and ran the real rotation script with a **non-existent tenant slug** — reached the tenant lookup and exited without writing, with `[SEED] Seed source is off, skip seeding` confirmed in the same run.
- **Signature rollover, state detection only**: verified against real Infisical that both `production` and `preview` read as `not-started`, which is correct.
- `nx affected -t lint test` green across 27 projects; `tsc` clean for `apps/cms` and `tools`; `nx sync:check` clean

**Not tested:** any actual mutation. No key was ever written, no secret staged or deleted, and the production database path was never executed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)