### PR TITLE
feat(cms): tenant locale and theme defaults in admin

### DIFF
--- a/apps/cms/src/collections/users/hooks/apply-tenant-locale.hook.ts
+++ b/apps/cms/src/collections/users/hooks/apply-tenant-locale.hook.ts
@@ -1,0 +1,129 @@
+import { getUserTenantIDs, hasRole } from '@codeware/app-cms/util/misc';
+import type { User } from '@codeware/shared/util/payload-types';
+import { getTenantFromCookie } from '@payloadcms/plugin-multi-tenant/utilities';
+import type { CollectionAfterLoginHook } from 'payload';
+
+import { resolveScopedTenant } from '../../../security/resolve-scoped-tenant';
+
+/**
+ * Selects the tenant's default locale in the admin UI on every login.
+ *
+ * Payload resolves the content locale from `?locale=` -> the user's `locale`
+ * preference -> the config default, so writing the preference here opens the
+ * admin in the same locale the client renders.
+ *
+ * The tenant is the scoped one in tenant mode. In host mode the admin restores
+ * the last selected workspace from the tenant cookie, so that one wins as long
+ * as the user still has access to it, before falling back to their first
+ * tenant. Users without tenants keep the config default.
+ *
+ * Failures are non-fatal — a login must never break on a preference write.
+ */
+/**
+ * Tenant the admin will open on, when no tenant is scoped by the deployment.
+ *
+ * The selector restores the workspace from the tenant cookie, so a stale or
+ * foreign cookie is ignored — system users reach every tenant, everyone else
+ * only their own.
+ */
+const resolveHostModeTenantId = (
+  req: Parameters<CollectionAfterLoginHook<User>>[0]['req'],
+  user: User
+): number | undefined => {
+  const userTenantIds = getUserTenantIDs(user);
+  const cookieTenantId = Number(getTenantFromCookie(req.headers, 'text'));
+
+  if (
+    cookieTenantId &&
+    (hasRole(user, 'system-user') || userTenantIds.includes(cookieTenantId))
+  ) {
+    return cookieTenantId;
+  }
+
+  return userTenantIds[0];
+};
+
+export const applyTenantLocaleHook: CollectionAfterLoginHook<User> = async ({
+  req,
+  user
+}) => {
+  const { payload } = req;
+
+  // Login runs in a transaction and the preference field derives its owner from
+  // `req.user`, which login hasn't set yet. A copy carries the transaction into
+  // every call below — writing outside it deadlocks against the open login —
+  // while keeping the added identity off the request Payload is still using.
+  const localReq = { ...req, user: { ...user, collection: 'users' as const } };
+
+  try {
+    const scopedTenant = await resolveScopedTenant(payload);
+    const tenantId = scopedTenant?.id ?? resolveHostModeTenantId(req, user);
+    if (!tenantId) {
+      return user;
+    }
+
+    const { docs: settings } = await payload.find({
+      collection: 'site-settings',
+      where: { tenant: { equals: tenantId } },
+      limit: 1,
+      depth: 0,
+      overrideAccess: true,
+      req: localReq
+    });
+
+    const locale = settings[0]?.general?.defaultLocale;
+    if (!locale) {
+      return user;
+    }
+
+    const { docs: preferences } = await payload.find({
+      collection: 'payload-preferences',
+      where: {
+        and: [
+          { key: { equals: 'locale' } },
+          { 'user.relationTo': { equals: 'users' } },
+          { 'user.value': { equals: user.id } }
+        ]
+      },
+      limit: 1,
+      depth: 0,
+      overrideAccess: true,
+      req: localReq
+    });
+
+    const preference = preferences[0];
+    if (preference?.value === locale) {
+      return user;
+    }
+
+    if (preference) {
+      await payload.update({
+        collection: 'payload-preferences',
+        id: preference.id,
+        data: { value: locale },
+        overrideAccess: true,
+        req: localReq
+      });
+    } else {
+      await payload.create({
+        collection: 'payload-preferences',
+        data: {
+          key: 'locale',
+          // Overwritten from `req.user` by the field's own hook, but required
+          user: { relationTo: 'users', value: user.id },
+          value: locale
+        },
+        overrideAccess: true,
+        req: localReq
+      });
+    }
+  } catch (error) {
+    payload.logger.warn(
+      `[applyTenantLocale] Could not apply tenant locale for '${user.email}': ${
+        error instanceof Error ? error.message : error
+      }`
+    );
+  }
+
+  return user;
+};

--- a/apps/cms/src/collections/users/users.collection.ts
+++ b/apps/cms/src/collections/users/users.collection.ts
@@ -16,6 +16,7 @@ import { CollectionConfig, Condition } from 'payload';
 
 import { adminAccessToAllDocTenants } from './access/admin-access-to-all-doc-tenants';
 import { tenantsArrayField } from './fields/tenants-array.field';
+import { applyTenantLocaleHook } from './hooks/apply-tenant-locale.hook';
 import { ensureTenantHook } from './hooks/ensure-tenant.hook';
 import { validateTenantsArrayAccessHook } from './hooks/validate-tenants-array-access.hook';
 import { verifyTenantModeAccessHook } from './hooks/verify-tenant-mode-access.hook';
@@ -76,7 +77,7 @@ const users: CollectionConfig<'users'> = {
   hooks: {
     beforeValidate: [ensureTenantHook],
     beforeChange: [validateTenantsArrayAccessHook],
-    afterLogin: [verifyTenantModeAccessHook]
+    afterLogin: [verifyTenantModeAccessHook, applyTenantLocaleHook]
   },
   fields: [
     {

--- a/apps/cms/src/components/admin/ThemeSwitch.client.tsx
+++ b/apps/cms/src/components/admin/ThemeSwitch.client.tsx
@@ -6,33 +6,50 @@ import type {
 } from '@codeware/app-cms/util/i18n';
 import { Button } from '@codeware/shared/ui/shadcn/components/button';
 import { cn } from '@codeware/shared/util/ui';
-import { MoonIcon, SunIcon } from '@heroicons/react/24/outline';
+import {
+  ComputerDesktopIcon,
+  MoonIcon,
+  SunIcon
+} from '@heroicons/react/24/outline';
 import type { Theme } from '@payloadcms/ui';
 import { useTheme, useTranslation } from '@payloadcms/ui';
 import React from 'react';
 
+type ThemeOption = Theme | 'auto';
+
 /**
- * Compact light/dark pill for Payload's toolbar (`admin.components.actions`),
- * giving editors one-click access to the theme instead of digging into the
- * account page. Persistence comes from Payload's own `useTheme` provider.
+ * Compact system/light/dark pill for Payload's toolbar
+ * (`admin.components.actions`), giving editors one-click access to the theme
+ * instead of digging into the account page. Persistence comes from Payload's
+ * own `useTheme` provider.
+ *
+ * `auto` follows the operating system preference and is the state until an
+ * explicit choice is made — Payload resolves it to light unless the OS asks
+ * for dark.
  */
 export function ThemeSwitch() {
-  const { setTheme, theme } = useTheme();
+  const { autoMode, setTheme, theme } = useTheme();
   const { t } = useTranslation<TranslationsObject, TranslationsKeys>();
 
-  const options: { value: Theme; icon: typeof SunIcon; label: string }[] = [
-    { value: 'light', icon: SunIcon, label: t('nav:themeLight') },
-    { value: 'dark', icon: MoonIcon, label: t('nav:themeDark') }
-  ];
+  const options: { value: ThemeOption; icon: typeof SunIcon; label: string }[] =
+    [
+      { value: 'auto', icon: ComputerDesktopIcon, label: t('nav:themeAuto') },
+      { value: 'light', icon: SunIcon, label: t('nav:themeLight') },
+      { value: 'dark', icon: MoonIcon, label: t('nav:themeDark') }
+    ];
+
+  const current: ThemeOption = autoMode ? 'auto' : theme;
 
   return (
     <div className="codeware-admin twp border-border bg-background flex items-center gap-0.5 rounded-full border p-0.5">
       {options.map(({ value, icon: Icon, label }) => {
-        const active = theme === value;
+        const active = current === value;
         return (
           <Button
             key={value}
-            onClick={() => setTheme(value)}
+            // `auto` is handled by the provider but missing from its types,
+            // just like Payload's own account page toggle
+            onClick={() => setTheme(value as Theme)}
             variant="ghost"
             size="icon-xs"
             aria-pressed={active}

--- a/apps/web/app/utils/theme.server.ts
+++ b/apps/web/app/utils/theme.server.ts
@@ -9,6 +9,9 @@ const cookie = createCookie(cookieName);
 /**
  * Get the theme from the 'en_theme' cookie if present.
  *
+ * Without the cookie there is no explicit user choice, so the caller falls
+ * back to the client hint (the OS preference) and ultimately to light mode.
+ *
  * @param request The incoming request
  *
  * @returns The user selected theme or null if the theme is not set
@@ -17,7 +20,7 @@ export async function getTheme(request: Request) {
   const cookieHeader = request.headers.get('cookie');
   const parsed: Theme | null = cookieHeader
     ? await cookie.parse(cookieHeader)
-    : 'light';
+    : null;
   if (parsed === 'light' || parsed === 'dark') {
     return parsed;
   }

--- a/libs/app-cms/util/i18n/src/lib/custom-translations.ts
+++ b/libs/app-cms/util/i18n/src/lib/custom-translations.ts
@@ -85,6 +85,7 @@ const customTranslationsSchema = z.object({
     roleEditor: z.string(),
     roleSystemAdmin: z.string(),
     searchPlaceholder: z.string(),
+    themeAuto: z.string(),
     themeDark: z.string(),
     themeLight: z.string(),
     uploadMedia: z.string()
@@ -205,6 +206,7 @@ You can assign multiple tags to a file.`,
       roleEditor: 'Editor',
       roleSystemAdmin: 'System admin',
       searchPlaceholder: 'Filter menu…',
+      themeAuto: 'System mode',
       themeDark: 'Dark mode',
       themeLight: 'Light mode',
       uploadMedia: 'Upload media'
@@ -322,6 +324,7 @@ Du kan tilldela flera etiketter till en fil.`,
       roleEditor: 'Redaktör',
       roleSystemAdmin: 'Systemadministratör',
       searchPlaceholder: 'Filtrera menyn…',
+      themeAuto: 'Systemläge',
       themeDark: 'Mörkt läge',
       themeLight: 'Ljust läge',
       uploadMedia: 'Ladda upp media'


### PR DESCRIPTION
Two small preference fixes that belong together: what the admin opens with after login.

### COD-429 — tenant default locale in admin

Payload resolves the admin content locale from `?locale=` → the user's `locale` preference → the config default (`en`). A new `afterLogin` hook writes that preference from the tenant's `site-settings.general.defaultLocale`, so the admin opens in the locale the client actually renders.

- Tenant is the scoped one in tenant mode. In host mode the admin restores the last selected workspace from the tenant cookie, so that one wins when the user still has access to it (system users reach every tenant), falling back to their first tenant.
- Applied on **every** login, so switching tenants doesn't leave a stale locale behind.
- Users without tenants (system users) keep the config default.
- Every call runs on a copy of the login `req`. Two reasons: login runs inside a transaction, and writing outside it deadlocks against the still-open login (the insert waits on a lock the login holds); and the preference's `user` field is populated by a `beforeValidate` hook that reads `req.user`, which login has not set yet — without the identity the field resolves to `null` and the write fails validation.
- Preference writes are non-fatal — a failure logs a warning and never blocks login.

### COD-430 — user preferred theme, falling back to light

Order is now: explicit user choice → OS preference → light, on both surfaces.

- **Admin**: the toolbar pill only offered light/dark, so once an editor picked one there was no way back to following the OS. Added a `system` option (Payload's `auto`), mirroring the web client's switch, with `nav:themeAuto` translations for en/sv.
- **Web**: `getTheme` returned `'light'` when the request carried no cookie header at all, which pinned light instead of deferring to the client hint. It now returns `null` so the hint applies, with light as the final fallback in `Document`.

The CMS site and frontend routes already run next-themes with `defaultTheme="system"`, so they conform as-is.

### Verification

Run against a local tenant-mode instance (tenant `moon`), not just static checks:

- **COD-429, tenant mode** — driven through `payload.login()` on the local API with the tenant's default locale temporarily set to `sv`: the hook created the `locale` preference as `sv`, and a second login after restoring the tenant to `en` updated the same row to `en`. Both the deadlock and the null-identity failure above were found this way and are fixed.
- **COD-429, host mode** — one login per case, covering the cookie-scoped tenant: `black` (moon+star+sun) with `payload-tenant=3` (sun, default `sv`) wrote `sv` rather than moon's `en`; the same user with `payload-tenant=1` wrote `en`; `titan` (moon only) with a cookie for sun fell back to `en`, cookie rejected; `titan` without a cookie wrote `en` from the first tenant.
- **COD-430** — Playwright in a fresh context (incognito-equivalent): the client renders `html.dark` under a dark OS and `html.light` under a light one, with the switch showing the monitor icon and "Current: system preference" in both cases. After logging into the admin with a dark OS and no theme cookie, the pill has `System mode` pressed and `data-theme="dark"`.

`lint` + `test` on `cms`, `web`, `app-cms-util-i18n`, `web:typecheck`, and `tsc --noEmit` on `apps/cms` all pass.

Closes COD-429
Closes COD-430

🤖 Generated with [Claude Code](https://claude.com/claude-code)
