### PR TITLE
ci(workflow): garbage collect app preview tags

### DIFF
--- a/.github/workflows/fly-deployment.yml
+++ b/.github/workflows/fly-deployment.yml
@@ -713,6 +713,9 @@ jobs:
           private-key: ${{ secrets.CDWR_ACTIONS_BOT_PRIVATE_KEY }}
 
       - uses: actions/checkout@v5
+        with:
+          # Delete release tags as the app, the ruleset's bypass actor
+          token: ${{ steps.generate-token.outputs.token }}
 
       - uses: pnpm/action-setup@v5
 
@@ -744,6 +747,38 @@ jobs:
           fly-trace-cli: ${{ vars.FLY_TRACE_CLI }}
           fly-console-logs: ${{ steps.flags.outputs.console-logs }}
           token: ${{ steps.generate-token.outputs.token }}
+
+      # Every preview push leaves an app tag behind, `<app>-<version>-preview.<pr>.<n>`.
+      # The lane belongs to this PR alone, so it goes the same way as its apps and
+      # database. Runs even if the destroy above failed — the two are independent.
+      - name: Delete preview tags
+        if: ${{ !cancelled() }}
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          set -euo pipefail
+          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "No PR number resolved, nothing to clean up"
+            exit 0
+          fi
+
+          # Read the remote directly — the checkout above is shallow and carries no tags
+          tags=()
+          while IFS= read -r tag; do
+            tags+=("$tag")
+          done < <(
+            git ls-remote --tags --refs origin "refs/tags/*-preview.${PR_NUMBER}.*" |
+              awk '{print $2}' |
+              grep -E "^refs/tags/.+-preview\.${PR_NUMBER}\.[0-9]+$" || true
+          )
+
+          if [ ${#tags[@]} -eq 0 ]; then
+            echo "No preview tags for PR #${PR_NUMBER}"
+            exit 0
+          fi
+
+          printf 'Deleting %s\n' "${tags[@]}"
+          git push --no-verify --atomic origin --delete "${tags[@]}"
 
   summary:
     needs:
@@ -787,11 +822,11 @@ jobs:
             echo "🚪 PR closed - running cleanup" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             if [ "$DESTROY_RESULT" = "success" ]; then
-              echo "✅ Preview apps destroyed successfully" >> $GITHUB_STEP_SUMMARY
+              echo "✅ Preview apps and tags cleaned up successfully" >> $GITHUB_STEP_SUMMARY
             elif [ "$DESTROY_RESULT" = "skipped" ]; then
-              echo "⏭️ No preview apps to destroy" >> $GITHUB_STEP_SUMMARY
+              echo "⏭️ Nothing to clean up" >> $GITHUB_STEP_SUMMARY
             else
-              echo "❌ Preview app cleanup failed or was cancelled" >> $GITHUB_STEP_SUMMARY
+              echo "❌ Preview cleanup failed or was cancelled" >> $GITHUB_STEP_SUMMARY
             fi
             exit 0
           fi

--- a/.github/workflows/fly-deployment.yml
+++ b/.github/workflows/fly-deployment.yml
@@ -193,7 +193,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: generate-token
         with:
-          app-id: ${{ secrets.CDWR_ACTIONS_BOT_ID }}
+          client-id: ${{ secrets.CDWR_ACTIONS_BOT_ID }}
           private-key: ${{ secrets.CDWR_ACTIONS_BOT_PRIVATE_KEY }}
 
       # Privileged job (secrets + write token) — keep the default ref, never
@@ -364,7 +364,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: generate-token
         with:
-          app-id: ${{ secrets.CDWR_ACTIONS_BOT_ID }}
+          client-id: ${{ secrets.CDWR_ACTIONS_BOT_ID }}
           private-key: ${{ secrets.CDWR_ACTIONS_BOT_PRIVATE_KEY }}
 
       - uses: actions/checkout@v5
@@ -560,7 +560,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: generate-token
         with:
-          app-id: ${{ secrets.CDWR_ACTIONS_BOT_ID }}
+          client-id: ${{ secrets.CDWR_ACTIONS_BOT_ID }}
           private-key: ${{ secrets.CDWR_ACTIONS_BOT_PRIVATE_KEY }}
 
       # workflow_run payload, then pull_request event, then manual dispatch input
@@ -709,7 +709,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: generate-token
         with:
-          app-id: ${{ secrets.CDWR_ACTIONS_BOT_ID }}
+          client-id: ${{ secrets.CDWR_ACTIONS_BOT_ID }}
           private-key: ${{ secrets.CDWR_ACTIONS_BOT_PRIVATE_KEY }}
 
       - uses: actions/checkout@v5

--- a/.github/workflows/nx-migrate.yml
+++ b/.github/workflows/nx-migrate.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: generate-token
         with:
-          app-id: ${{ secrets.CDWR_ACTIONS_BOT_ID }}
+          client-id: ${{ secrets.CDWR_ACTIONS_BOT_ID }}
           private-key: ${{ secrets.CDWR_ACTIONS_BOT_PRIVATE_KEY }}
 
       - uses: actions/checkout@v5

--- a/.github/workflows/preview-tag-sweep.yml
+++ b/.github/workflows/preview-tag-sweep.yml
@@ -1,0 +1,121 @@
+name: Preview tag sweep
+
+# Preview deployments tag every push as `<app>-<version>-preview.<pr>.<n>`.
+# `fly-deployment.yml` drops a PR's lane when the PR closes, but a failed or
+# cancelled destroy job — and anything tagged before that cleanup existed —
+# leaves the lane behind. This sweeps whatever is left.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "List the tags that would be deleted without deleting them"
+        required: false
+        type: boolean
+        default: false
+  schedule:
+    # Every Monday at 5am UTC
+    - cron: 0 5 * * 1
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/create-github-app-token@v3
+        id: generate-token
+        with:
+          app-id: ${{ secrets.CDWR_ACTIONS_BOT_ID }}
+          private-key: ${{ secrets.CDWR_ACTIONS_BOT_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v5
+        with:
+          # Delete release tags as the app, the ruleset's bypass actor
+          token: ${{ steps.generate-token.outputs.token }}
+
+      - name: Sweep preview tags
+        env:
+          DRY_RUN: ${{ inputs.dry-run }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          set -euo pipefail
+
+          # Read the remote directly — the checkout above is shallow and carries no tags
+          tags=()
+          while IFS= read -r tag; do
+            tags+=("$tag")
+          done < <(
+            git ls-remote --tags --refs origin 'refs/tags/*-preview.*' |
+              awk '{print $2}' |
+              grep -E '^refs/tags/.+-preview\.[0-9]+\.[0-9]+$' || true
+          )
+
+          if [ ${#tags[@]} -eq 0 ]; then
+            echo "No preview tags found" | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          prs=()
+          while IFS= read -r pr; do
+            prs+=("$pr")
+          done < <(
+            printf '%s\n' "${tags[@]}" |
+              sed -E 's/.*-preview\.([0-9]+)\.[0-9]+$/\1/' | sort -un
+          )
+          echo "Found ${#tags[@]} preview tags across ${#prs[@]} PR lanes"
+
+          stale=()
+          for pr in "${prs[@]}"; do
+            # An API hiccup must not be read as "PR is gone" — only a definitive
+            # not-found sweeps a lane whose PR no longer exists
+            if state="$(gh pr view "$pr" --json state --jq .state 2>&1)"; then
+              :
+            elif grep -qiE 'not found|no pull requests found|could not resolve' <<< "$state"; then
+              state=MISSING
+            else
+              echo "::warning::Could not resolve PR #${pr} ($state) — keeping its lane"
+              continue
+            fi
+
+            if [ "$state" = "OPEN" ]; then
+              echo "PR #${pr} is open — keeping its lane"
+              continue
+            fi
+
+            echo "PR #${pr} is ${state} — sweeping its lane"
+            while IFS= read -r tag; do
+              stale+=("$tag")
+            done < <(printf '%s\n' "${tags[@]}" | grep -E -- "-preview\.${pr}\.[0-9]+$")
+          done
+
+          if [ ${#stale[@]} -eq 0 ]; then
+            echo "Nothing to sweep" | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          {
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "### 🔍 Preview tag sweep (dry run) — ${#stale[@]} tags"
+            else
+              echo "### 🧹 Preview tag sweep — ${#stale[@]} tags deleted"
+            fi
+            echo ""
+            printf -- '- `%s`\n' "${stale[@]#refs/tags/}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "Dry run — leaving ${#stale[@]} tags in place"
+            printf '%s\n' "${stale[@]}"
+            exit 0
+          fi
+
+          # Not atomic: one unexpected ref must not block the rest of the sweep
+          git push --no-verify origin --delete "${stale[@]}"

--- a/.github/workflows/preview-tag-sweep.yml
+++ b/.github/workflows/preview-tag-sweep.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: generate-token
         with:
-          app-id: ${{ secrets.CDWR_ACTIONS_BOT_ID }}
+          client-id: ${{ secrets.CDWR_ACTIONS_BOT_ID }}
           private-key: ${{ secrets.CDWR_ACTIONS_BOT_PRIVATE_KEY }}
 
       - uses: actions/checkout@v5


### PR DESCRIPTION
Closes COD-420.

Preview deployments tag every push as `<app>-<version>-preview.<pr>.<n>`. Nothing removed them, so they accumulated — 82 on the remote right now. Fly preview apps and databases are already torn down on PR close; tags now follow the same lifecycle.

## On PR close

New `Delete preview tags` step in the existing `destroy` job, alongside `Destroy preview apps`:

- Enumerates remote tags via `git ls-remote` (the job's checkout is shallow and carries no tags), filtered by glob **and** an anchored regex on `-preview.<pr>.<n>`.
- Deletes the lane wholesale with one atomic `git push --delete`. The SHA in the About UI already identifies a build, so nothing is kept for traceability.
- Runs on `!cancelled()` — a failed Fly destroy shouldn't strand the tags, the two are independent.
- No-ops cleanly when the PR produced no preview deployment or the number is missing/non-numeric.

The job's `actions/checkout` now takes the GitHub App token, as the `deploy` job does — the default `GITHUB_TOKEN` is read-only on fork `pull_request` events, and the app is the tag ruleset's bypass actor.

## Scheduled sweep

New `preview-tag-sweep.yml` (Mondays 05:00 UTC + `workflow_dispatch` with a `dry-run` input) covers what the on-close path can't: the existing backlog, and lanes orphaned by a failed or cancelled destroy job.

It groups remote preview tags by PR, asks the API for each PR's state, and sweeps every lane whose PR is not `OPEN`. A definitive "not found" counts as sweepable; any other API error keeps the lane and emits a warning, so a transient failure can't delete an open PR's tags. The push is non-atomic here — one unexpected ref shouldn't block the rest of the sweep.

## Verification

Both scripts were extracted from the YAML and run locally against the real remote tag list, with `gh` and `git push` stubbed:

- Sweep with 465 open, 466 erroring, rest merged → 61 of 82 tags selected; PR 465's and 466's lanes untouched, no stable tag ever selected.
- On-close step for PR 465 → exactly its 18 tags. `99999`, `not-a-number` and empty all no-op.
- Prefix collisions checked: `PR_NUMBER=46` and `=4` match nothing, despite lanes 462/464/465 existing.
- Both workflows parse as YAML.

Out of scope: the preview base-version issue noted on the ticket (Nx resolves a prerelease specifier without consulting commit types) — that's versioning correctness, not GC.